### PR TITLE
Store a list of reserved slots.

### DIFF
--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -230,7 +230,7 @@ handle_info({'EXIT', From, _Reason}, #state{connections=Connections0}=State) ->
     Connections = dict:fold(FoldFun, Connections0, Connections0),
     {noreply, State#state{connections=Connections}};
 
-handle_info({connected, Node, RemoteState},
+handle_info({connected, Node, _Tag, RemoteState},
                #state{pending=Pending0,
                       membership=Membership0,
                       connections=Connections}=State) ->

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -902,9 +902,14 @@ is_full({passive, Passive}, MaxPassiveSize) ->
 %% @doc Process of removing a random element from the active view.
 drop_random_element_from_active_view(#state{myself=Myself,
                                             active=Active0,
+                                            reserved=Reserved,
                                             passive=Passive0}=State) ->
-    %% Select random from the active view, but excluse ourselves.
-    case select_random(sets:del_element(Myself, Active0)) of
+    ReservedPeers = dict:fold(fun(_K, V, Acc) -> [V | Acc] end,
+                              [],
+                              Reserved),
+    %% Select random peer, but omit the peers in reserved slots and omit
+    %% ourself from the active view.
+    case select_random(Active0, [Myself, ReservedPeers]) of
         undefined ->
             State;
         Peer ->

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -457,6 +457,18 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 
 %% @private
+handle_message({neighbor, Peer, Tag, _Sender}, State0) ->
+    lager:info("Neighboring with ~p from random walk.", [Peer]),
+
+    %% Add node into the active view.
+    State = add_to_active_view(Peer, Tag, State0),
+
+    %% Notify with event.
+    notify(State),
+
+    {reply, ok, State};
+
+%% @private
 handle_message({neighbor_accepted, Peer, Tag, _Sender}, State0) ->
     lager:info("Neighbor request accepted: ~p", [Peer]),
 
@@ -573,7 +585,7 @@ handle_message({forward_join, Peer, Tag, TTL, Sender},
             %% update it's view.
             %%
             do_send_message(Peer,
-                            {neighbor_accepted, Myself, Tag, Peer},
+                            {neighbor, Myself, Tag, Peer},
                             Connections),
 
             State1#state{connections=Connections};
@@ -608,11 +620,11 @@ handle_message({forward_join, Peer, Tag, TTL, Sender},
                                                         Active,
                                                         Connections0),
 
-                    %% Send neighbor_accapted message to origin, that will
+                    %% Send neighbor message to origin, that will
                     %% update it's view.
                     %%
                     do_send_message(Peer,
-                                    {neighbor_accepted, Myself, Tag, Peer},
+                                    {neighbor, Myself, Tag, Peer},
                                     Connections),
 
                     State2#state{connections=Connections};
@@ -1007,7 +1019,7 @@ perform_join(Peer, Tag,
     %% update it's view.
     %%
     do_send_message(Peer,
-                    {neighbor_accepted, Myself, Tag, Peer},
+                    {neighbor, Myself, Tag, Peer},
                     Connections),
 
     %% Notify with event.

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -414,9 +414,6 @@ handle_info({'EXIT', From, _Reason},
                           suspected=Suspected,
                           connections=Connections}};
 
-handle_info({connected, Peer, _RemoteState}, State) ->
-    handle_connect(Peer, undefined, State);
-
 handle_info({connected, Peer, Tag, _RemoteState}, State) ->
     handle_connect(Peer, Tag, State);
 

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -581,9 +581,8 @@ handle_message({forward_join, Peer, Tag, TTL, Sender},
                                                 Active,
                                                 Connections0),
 
-            %% Send neighbor_accapted message to origin, that will
-            %% update it's view.
-            %%
+            %% Send neighbor message to origin, that will update it's
+            %% view.
             do_send_message(Peer,
                             {neighbor, Myself, Tag, Peer},
                             Connections),

--- a/src/partisan_peer_service_client.erl
+++ b/src/partisan_peer_service_client.erl
@@ -90,8 +90,7 @@ handle_cast(Msg, State) ->
 -spec handle_info(term(), #state{}) -> {noreply, #state{}}.
 handle_info({tcp, _Socket, Data}, State0) ->
     handle_message(decode(Data), State0);
-handle_info({tcp_closed, _Socket}, #state{peer=Peer}=State) ->
-    lager:info("Socket closed: ~p!", [Peer]),
+handle_info({tcp_closed, _Socket}, State) ->
     {stop, normal, State};
 handle_info(Msg, State) ->
     lager:warning("Unhandled messages: ~p", [Msg]),

--- a/src/partisan_peer_service_client.erl
+++ b/src/partisan_peer_service_client.erl
@@ -142,9 +142,9 @@ decode(Message) ->
     binary_to_term(Message).
 
 %% @private
-handle_message({merge, LocalState},
+handle_message({state, Tag, LocalState},
                #state{peer=Peer, from=From}=State) ->
-    From ! {connected, Peer, LocalState},
+    From ! {connected, Peer, Tag, LocalState},
     {noreply, State};
 handle_message({hello, _Node}, #state{socket=Socket}=State) ->
     Message = {hello, node()},

--- a/src/partisan_peer_service_server.erl
+++ b/src/partisan_peer_service_server.erl
@@ -123,9 +123,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 
-handle_message({connected, _Node, _RemoteState} = Message, State) ->
-    ?PEER_SERVICE_MANAGER:receive_message(Message),
-    {noreply, State};
 handle_message({hello, Node},
                #state{socket=Socket, transport=Transport}=State) ->
     %% Connect the node with Distributed Erlang, just for now for

--- a/src/partisan_peer_service_server.erl
+++ b/src/partisan_peer_service_server.erl
@@ -125,12 +125,17 @@ code_change(_OldVsn, State, _Extra) ->
 
 handle_message({hello, Node},
                #state{socket=Socket, transport=Transport}=State) ->
+    %% Get our tag, if set.
+    Tag = partisan_config:get(tag, undefined),
+
     %% Connect the node with Distributed Erlang, just for now for
     %% control messaging in the test suite execution.
     case net_adm:ping(Node) of
         pong ->
+            %% Send our state to the remote service, incase they want
+            %% it to bootstrap.
             {ok, LocalState} = ?PEER_SERVICE_MANAGER:get_local_state(),
-            send_message(Socket, Transport, {merge, LocalState}),
+            send_message(Socket, Transport, {state, Tag, LocalState}),
             {noreply, State};
         pang ->
             lager:info("Node could not be connected."),


### PR DESCRIPTION
Allow peers to conenct with a tag, and reserve slots for those peers in
the active view, to guarantee that we are always connected to certain
types of peers.