### PR TITLE
support OS var configuration of ip, port and peer service

### DIFF
--- a/src/partisan.app.src
+++ b/src/partisan.app.src
@@ -1,7 +1,7 @@
 {application, partisan,
  [
   {description, "Scalable peer service for Lasp"},
-  {vsn, "0.0.1"},
+  {vsn, "0.1.0"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
These changes I think will allow lasp to not require partisan as an included application because you can set ip, port and peer service through the OS vars as is done in lasp itself currently.

I have a separate PR coming for lasp if this is merged.