### PR TITLE
New join API; Reconnect to disconnected peers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ deps/*
 ebin/*
 dev
 src/*.swp
+test/*.swp
 tags
 .qc/
 riak_test/ebin/*.beam

--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -4,9 +4,10 @@
 -define(PEER_SERVICE_SERVER, partisan_peer_service_server).
 -define(FANOUT, 5).
 
+-define(RECONNECT_INTERVAL, 10000). %% 10s
+
 -type actor() :: binary().
 -type connections() :: dict:dict(node(), port()).
--type pending() :: [node_spec()].
 -type node_spec() :: {node(), inet:ip_address(), non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().

--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -6,8 +6,10 @@
 
 -type actor() :: binary().
 -type connections() :: dict:dict(node(), port()).
+-type pending() :: [node_spec()].
 -type node_spec() :: {node(), inet:ip_address(), non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().
 -type partitions() :: [{reference(), node_spec()}].
 -type ttl() :: non_neg_integer().
+-type error() :: {error, term()}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
  {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},0},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.1">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
- {<<"types">>,{pkg,<<"types">>,<<"0.0.4">>},0}]}.
+ {<<"types">>,{pkg,<<"types">>,<<"0.1.2">>},0}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"679D741DF87FC13599B1AEF2DF8F78F1F880449A6BEFAB7C44FB6FAE0E92A2DE">>},
@@ -12,5 +12,5 @@
  {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
  {<<"rand_compat">>, <<"624B590931D27252D0BCF710211699DB3695540706F57D2E91B918A17AB58839">>},
  {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>},
- {<<"types">>, <<"B2BC2D58F12D85EFD06BC3A28B3DDE3C5AEF29EFB0FEE71FC2F1B6968C5E0DC1">>}]}
+ {<<"types">>, <<"F55716C10C7D304582D23BAF3C498704256D5A2F34E0B18E09BA0304F160FAE3">>}]}
 ].

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -205,7 +205,7 @@ handle_call({join, {Name, _, _}=Node},
 
     %% Return.
     {reply, Result, State#state{pending=Pending,
-                            connections=Connections}};
+                                connections=Connections}};
 
 handle_call({send_message, Name, Message}, _From,
             #state{connections=Connections}=State) ->

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -56,9 +56,7 @@
 -type membership() :: sets:set(node_spec()).
 -type tag() :: atom().
 
--record(state, {myself :: node_spec(),
-                tag :: tag(),
-                pending :: pending(),
+-record(state, {tag :: tag(),
                 membership :: membership(),
                 connections :: connections()}).
 
@@ -114,7 +112,7 @@ leave(Node) ->
 
 %% @doc Decode state.
 decode(State) ->
-    sets:to_list(State).
+    State.
 
 %% @doc Reserve a slot for the particular tag.
 reserve(Tag) ->
@@ -149,14 +147,13 @@ init([]) ->
 
     Membership = maybe_load_state_from_disk(),
     Connections = dict:new(),
-    Myself = myself(),
 
     %% Get tag, if set.
     Tag = partisan_config:get(tag, undefined),
 
+    schedule_reconnect(),
+
     {ok, #state{tag=Tag,
-                myself=Myself,
-                pending=[],
                 membership=Membership,
                 connections=Connections}}.
 
@@ -193,19 +190,15 @@ handle_call({leave, Node}, _From,
 
 handle_call({join, {Name, _, _}=Node},
             _From,
-            #state{pending=Pending0, connections=Connections0}=State) ->
+            #state{connections=Connections0}=State) ->
     %% Attempt to join via disterl for control messages during testing.
     _ = net_kernel:connect(Name),
-
-    %% Add to list of pending connections.
-    Pending = [Node|Pending0],
 
     %% Trigger connection.
     {Result, Connections} = maybe_connect(Node, Connections0),
 
     %% Return.
-    {reply, Result, State#state{pending=Pending,
-                                connections=Connections}};
+    {reply, Result, State#state{connections=Connections}};
 
 handle_call({send_message, Name, Message}, _From,
             #state{connections=Connections}=State) ->
@@ -222,8 +215,9 @@ handle_call({forward_message, Name, ServerRef, Message}, _From,
 handle_call({receive_message, Message}, _From, State) ->
     handle_message(Message, State);
 
-handle_call(members, _From, #state{membership=Membership}=State) ->
-    Members = [P || {P, _, _} <- members(Membership)],
+handle_call(members, _From, #state{membership=Membership,
+                                   connections=Connections}=State) ->
+    Members = [Name || {Name, _, _} <- membership(Membership, Connections)],
     {reply, {ok, Members}, State};
 
 handle_call(get_local_state, _From, #state{membership=Membership}=State) ->
@@ -239,59 +233,62 @@ handle_cast(Msg, State) ->
     lager:warning("Unhandled messages: ~p", [Msg]),
     {noreply, State}.
 
-handle_info({'EXIT', From, _Reason}, #state{connections=Connections0}=State) ->
+handle_info(reconnect, #state{membership=Membership,
+                              connections=Connections0}=State) ->
+
+    Connections = establish_connections(Membership, Connections0),
+
+    schedule_reconnect(),
+
+    {noreply, State#state{connections=Connections}};
+
+handle_info({'EXIT', From, _Reason}, #state{membership=Membership,
+                                            connections=Connections0}=State) ->
+
     FoldFun = fun(K, V, AccIn) ->
-                      case V =:= From of
-                          true ->
-                              dict:store(K, undefined, AccIn);
-                          false ->
-                              AccIn
-                      end
-              end,
+        case V =:= From of
+            true ->
+                dict:store(K, undefined, AccIn);
+            false ->
+                AccIn
+        end
+    end,
     Connections = dict:fold(FoldFun, Connections0, Connections0),
+
+    %% Announce to the peer service.
+    ActualMembership = membership(Membership, Connections),
+    partisan_peer_service_events:update(ActualMembership),
+
     {noreply, State#state{connections=Connections}};
 
 handle_info({connected, Node, TheirTag, _RemoteState},
-               #state{pending=Pending0,
-                      tag=OurTag,
+               #state{tag=OurTag,
                       membership=Membership0,
-                      connections=Connections0}=State) ->
-    case lists:member(Node, Pending0) of
+                      connections=Connections}=State) ->
+
+    case accept_join_with_tag(OurTag, TheirTag) of
         true ->
-            case accept_join_with_tag(OurTag, TheirTag) of
-                true ->
-                    %% Move out of pending.
-                    Pending = Pending0 -- [Node],
+            %% Add to our membership.
+            Membership = sets:add_element(Node, Membership0),
+            persist_state(Membership),
 
-                    %% Add to our membership.
-                    Membership = sets:add_element(Node, Membership0),
+            %% Announce to the peer service.
+            ActualMembership = membership(Membership, Connections),
+            partisan_peer_service_events:update(Membership),
 
-                    %% Announce to the peer service.
-                    partisan_peer_service_events:update(Membership),
+            %% Compute count.
+            Count = length(ActualMembership),
 
-                    %% Establish any new connections.
-                    Connections = establish_connections(Pending,
-                                                        Membership,
-                                                        Connections0),
+            lager:info("Join ACCEPTED with ~p; node is ~p and we are ~p: we have ~p members in our view.",
+                       [Node, TheirTag, OurTag, Count]),
 
-                    %% Compute count.
-                    Count = sets:size(Membership),
-
-                    lager:info("Join ACCEPTED with ~p; node is ~p and we are ~p: we have ~p members in our view.",
-                               [Node, TheirTag, OurTag, Count]),
-
-                    %% Return.
-                    {noreply, State#state{pending=Pending,
-                                          connections=Connections,
-                                          membership=Membership}};
-                false ->
-                    lager:info("Join REFUSED with ~p; node is ~p and we are ~p",
-                               [Node, TheirTag, OurTag]),
-                    lager:info("Keeping membership: ~p", [Membership0]),
-
-                    {noreply, State}
-            end;
+            %% Return.
+            {noreply, State#state{membership=Membership}};
         false ->
+            lager:info("Join REFUSED with ~p; node is ~p and we are ~p",
+                       [Node, TheirTag, OurTag]),
+            lager:info("Keeping membership: ~p",  membership(Membership0, Connections)),
+
             {noreply, State}
     end;
 
@@ -384,15 +381,11 @@ persist_state(State) ->
     write_state_to_disk(State).
 
 %% @private
-members(Membership) ->
-    sets:to_list(Membership).
-
-%% @private
-establish_connections(Pending, Membership, Connections) ->
-    Members = members(Membership),
-    partisan_util:establish_connections(Pending,
-                                        Members,
-                                        Connections).
+establish_connections(Membership, Connections) ->
+    partisan_util:establish_connections(
+        sets:to_list(Membership),
+        Connections
+    ).
 
 %% @private
 maybe_connect(Node, Connections) ->
@@ -441,3 +434,23 @@ accept_join_with_tag(OurTag, TheirTag) ->
                     false
             end
     end.
+
+%% @private
+membership(Membership, Connections) ->
+    lists:filter(
+        fun({Name, _, _}) ->
+            case dict:find(Name, Connections) of
+                {ok, undefined} ->
+                    false;
+                {ok, _Pid} ->
+                    true;
+                error ->
+                    false
+            end
+        end,
+        sets:to_list(Membership)
+    ).
+
+%% @private
+schedule_reconnect() ->
+    timer:send_after(?RECONNECT_INTERVAL, reconnect).

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -439,14 +439,16 @@ accept_join_with_tag(OurTag, TheirTag) ->
 membership(Membership, Connections) ->
     lists:filter(
         fun({Name, _, _}) ->
-            case dict:find(Name, Connections) of
+            Connected = case dict:find(Name, Connections) of
                 {ok, undefined} ->
                     false;
                 {ok, _Pid} ->
                     true;
                 error ->
                     false
-            end
+            end,
+
+            Connected orelse Name == node()
         end,
         sets:to_list(Membership)
     ).

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -286,7 +286,6 @@ handle_info({connected, _Node, _Tag, RemoteState},
                       connections=Connections}=State) ->
 
     %% Update membership by joining with remote membership.
-    lager:info("connected BF ~p", [RemoteState]),
     Membership = ?SET:merge(RemoteState, Membership0),
     persist_state(Membership),
 

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -453,7 +453,6 @@ do_gossip(Membership, Connections) ->
     Fanout = partisan_config:get(fanout, ?FANOUT),
 
     ActualMembership = membership(Membership, Connections),
-    lager:info("M ~p, C ~p, A ~p", [Membership, Connections, ActualMembership]),
     Peers = [Name || {Name, _, _} <- ActualMembership, Name /= node()],
     PeersFanout = random_peers(Peers, Fanout),
 

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -217,7 +217,7 @@ handle_call({join, {Name, _, _}=Node},
 
     %% Return.
     {reply, Result, State#state{pending=Pending,
-                            connections=Connections}};
+                                connections=Connections}};
 
 handle_call({send_message, Name, Message}, _From,
             #state{connections=Connections}=State) ->

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -54,7 +54,6 @@
 
 -define(SET, state_orset).
 
--type pending() :: [node_spec()].
 -type membership() :: ?SET:state_orset().
 
 -record(state, {actor :: actor(),
@@ -70,7 +69,7 @@
 %%%===================================================================
 
 %% @doc Same as start_link([]).
--spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+-spec start_link() -> {ok, pid()} | ignore | error().
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
@@ -214,10 +213,10 @@ handle_call({join, {Name, _, _}=Node},
     Pending = [Node|Pending0],
 
     %% Trigger connection.
-    Connections = maybe_connect(Node, Connections0),
+    {Result, Connections} = maybe_connect(Node, Connections0),
 
     %% Return.
-    {reply, ok, State#state{pending=Pending,
+    {reply, Result, State#state{pending=Pending,
                             connections=Connections}};
 
 handle_call({send_message, Name, Message}, _From,
@@ -401,45 +400,14 @@ members(Membership) ->
 
 %% @private
 establish_connections(Pending, Membership, Connections) ->
-    %% Reconnect disconnected members and members waiting to join.
     Members = members(Membership),
-    AllPeers = lists:keydelete(node(), 1, Members ++ Pending),
-    lists:foldl(fun maybe_connect/2, Connections, AllPeers).
+    partisan_util:establish_connections(Pending,
+                                        Members,
+                                        Connections).
 
 %% @private
-%%
-%% Function should enforce the invariant that all cluster members are
-%% keys in the dict pointing to undefined if they are disconnected or a
-%% socket pid if they are connected.
-%%
-maybe_connect({Name, _, _} = Node, Connections0) ->
-    Connections = case dict:find(Name, Connections0) of
-        %% Found in dict, and disconnected.
-        {ok, undefined} ->
-            case connect(Node) of
-                {ok, Pid} ->
-                    dict:store(Name, Pid, Connections0);
-                _ ->
-                    dict:store(Name, undefined, Connections0)
-            end;
-        %% Found in dict and connected.
-        {ok, _Pid} ->
-            Connections0;
-        %% Not present; disconnected.
-        error ->
-            case connect(Node) of
-                {ok, Pid} ->
-                    dict:store(Name, Pid, Connections0);
-                _ ->
-                    dict:store(Name, undefined, Connections0)
-            end
-    end,
-    Connections.
-
-%% @private
-connect(Node) ->
-    Self = self(),
-    partisan_peer_service_client:start_link(Node, Self).
+maybe_connect(Node, Connections) ->
+    partisan_util:maybe_connect(Node, Connections).
 
 %% @private
 handle_message({receive_state, PeerMembership},

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -507,14 +507,16 @@ down(Name, #state{down_functions=DownFunctions}) ->
 membership(Membership, Connections) ->
     lists:filter(
         fun({Name, _, _}) ->
-            case dict:find(Name, Connections) of
+            Connected = case dict:find(Name, Connections) of
                 {ok, undefined} ->
                     false;
                 {ok, _Pid} ->
                     true;
                 error ->
                     false
-            end
+            end,
+
+            Connected orelse Name == node()
         end,
         to_list(Membership)
     ).

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -57,7 +57,6 @@
 -type membership() :: ?SET:state_orset().
 
 -record(state, {actor :: actor(),
-                pending :: pending(),
                 down_functions :: dict:dict(),
                 membership :: membership(),
                 connections :: connections()}).
@@ -114,7 +113,7 @@ leave(Node) ->
 
 %% @doc Decode state.
 decode(State) ->
-    sets:to_list(?SET:query(State)).
+    State.
 
 %% @doc Reserve a slot for the particular tag.
 reserve(Tag) ->
@@ -154,8 +153,9 @@ init([]) ->
     Membership = maybe_load_state_from_disk(Actor),
     Connections = dict:new(),
 
+    schedule_reconnect(),
+
     {ok, #state{actor=Actor,
-                pending=[],
                 membership=Membership,
                 connections=Connections,
                 down_functions=dict:new()}}.
@@ -175,7 +175,6 @@ handle_call({on_down, Name, Function},
 
 handle_call({leave, Node}, _From,
             #state{actor=Actor,
-                   connections=Connections,
                    membership=Membership0}=State) ->
     %% Node may exist in the membership on multiple ports, so we need to
     %% remove all.
@@ -187,10 +186,7 @@ handle_call({leave, Node}, _From,
                             _ ->
                                 L0
                         end
-                end, Membership0, decode(Membership0)),
-
-    %% Gossip.
-    do_gossip(Membership, Connections),
+                end, Membership0, to_list(Membership0)),
 
     %% Remove state and shutdown if we are removing ourselves.
     case node() of
@@ -205,19 +201,15 @@ handle_call({leave, Node}, _From,
 
 handle_call({join, {Name, _, _}=Node},
             _From,
-            #state{pending=Pending0, connections=Connections0}=State) ->
+            #state{connections=Connections0}=State) ->
     %% Attempt to join via disterl for control messages during testing.
     _ = net_kernel:connect(Name),
-
-    %% Add to list of pending connections.
-    Pending = [Node|Pending0],
 
     %% Trigger connection.
     {Result, Connections} = maybe_connect(Node, Connections0),
 
     %% Return.
-    {reply, Result, State#state{pending=Pending,
-                                connections=Connections}};
+    {reply, Result, State#state{connections=Connections}};
 
 handle_call({send_message, Name, Message}, _From,
             #state{connections=Connections}=State) ->
@@ -234,8 +226,9 @@ handle_call({forward_message, Name, ServerRef, Message}, _From,
 handle_call({receive_message, Message}, _From, State) ->
     handle_message(Message, State);
 
-handle_call(members, _From, #state{membership=Membership}=State) ->
-    Members = [P || {P, _, _} <- members(Membership)],
+handle_call(members, _From, #state{membership=Membership,
+                                   connections=Connections}=State) ->
+    Members = [Name || {Name, _, _} <- membership(Membership, Connections)],
     {reply, {ok, Members}, State};
 
 handle_call(get_local_state, _From, #state{membership=Membership}=State) ->
@@ -253,51 +246,55 @@ handle_cast(Msg, State) ->
 
 %% @private
 -spec handle_info(term(), state_t()) -> {noreply, state_t()}.
-handle_info(gossip, #state{pending=Pending,
-                           membership=Membership,
-                           connections=Connections0}=State) ->
-    Connections = establish_connections(Pending, Membership, Connections0),
+handle_info(gossip, #state{membership=Membership,
+                           connections=Connections}=State) ->
     do_gossip(Membership, Connections),
     schedule_gossip(),
+    {noreply, State};
+
+handle_info(reconnect, #state{membership=Membership,
+                              connections=Connections0}=State) ->
+
+    Connections = establish_connections(Membership, Connections0),
+
+    schedule_reconnect(),
+
     {noreply, State#state{connections=Connections}};
 
-handle_info({'EXIT', From, _Reason}, #state{connections=Connections0}=State) ->
+handle_info({'EXIT', From, _Reason}, #state{membership=Membership,
+                                            connections=Connections0}=State) ->
+
     FoldFun = fun(K, V, AccIn) ->
-                      case V =:= From of
-                          true ->
-                              down(K, State),
-                              dict:store(K, undefined, AccIn);
-                          false ->
-                              AccIn
-                      end
-              end,
+        case V =:= From of
+            true ->
+                down(K, State),
+                dict:store(K, undefined, AccIn);
+            false ->
+                AccIn
+        end
+    end,
     Connections = dict:fold(FoldFun, Connections0, Connections0),
+
+    %% Annouce to the peer service.
+    ActualMembership = membership(Membership, Connections),
+    partisan_peer_service_events:update(ActualMembership),
+
     {noreply, State#state{connections=Connections}};
 
-handle_info({connected, Node, _Tag, RemoteState},
-               #state{pending=Pending0,
-                      membership=Membership0,
+handle_info({connected, _Node, _Tag, RemoteState},
+               #state{membership=Membership0,
                       connections=Connections}=State) ->
-    case lists:member(Node, Pending0) of
-        true ->
-            %% Move out of pending.
-            Pending = Pending0 -- [Node],
 
-            %% Update membership by joining with remote membership.
-            Membership = ?SET:merge(RemoteState, Membership0),
+    %% Update membership by joining with remote membership.
+    Membership = ?SET:merge(RemoteState, Membership0),
+    persist_state(Membership),
 
-            %% Announce to the peer service.
-            partisan_peer_service_events:update(Membership),
+    %% Announce to the peer service.
+    ActualMembership = membership(Membership, Connections),
+    partisan_peer_service_events:update(ActualMembership),
 
-            %% Gossip the new membership.
-            do_gossip(Membership, Connections),
-
-            %% Return.
-            {noreply, State#state{pending=Pending,
-                                  membership=Membership}};
-        false ->
-            {noreply, State}
-    end;
+    %% Return.
+    {noreply, State#state{membership=Membership}};
 
 handle_info(Msg, State) ->
     lager:warning("Unhandled messages: ~p", [Msg]),
@@ -395,15 +392,16 @@ persist_state(State) ->
     write_state_to_disk(State).
 
 %% @private
-members(Membership) ->
+-spec to_list(membership()) -> list(node_spec()).
+to_list(Membership) ->
     sets:to_list(?SET:query(Membership)).
 
 %% @private
-establish_connections(Pending, Membership, Connections) ->
-    Members = members(Membership),
-    partisan_util:establish_connections(Pending,
-                                        Members,
-                                        Connections).
+establish_connections(Membership, Connections) ->
+    partisan_util:establish_connections(
+        to_list(Membership),
+        Connections
+    ).
 
 %% @private
 maybe_connect(Node, Connections) ->
@@ -411,45 +409,33 @@ maybe_connect(Node, Connections) ->
 
 %% @private
 handle_message({receive_state, PeerMembership},
-               #state{pending=Pending,
-                      membership=Membership,
-                      connections=Connections0}=State) ->
-    case ?SET:equal(PeerMembership, Membership) of
+               #state{membership=Membership0,
+                      connections=Connections}=State) ->
+    case ?SET:equal(PeerMembership, Membership0) of
         true ->
             %% No change.
             {reply, ok, State};
         false ->
             %% Merge data items.
-            Merged = ?SET:merge(PeerMembership, Membership),
+            Membership = ?SET:merge(PeerMembership, Membership0),
 
             %% Persist state.
-            persist_state(Merged),
+            persist_state(Membership),
 
-            %% Update users of the peer service.
-            partisan_peer_service_events:update(Merged),
-
-            %% Compute members.
-            Members = [N || {N, _, _} <- members(Merged)],
+            %% Announce to the peer service.
+            ActualMembership = membership(Membership, Connections),
+            partisan_peer_service_events:update(ActualMembership),
 
             %% Shutdown if we've been removed from the cluster.
-            case lists:member(node(), Members) of
+            case lists:member(myself(), ActualMembership) of
                 true ->
-                    %% Establish any new connections.
-                    Connections = establish_connections(Pending,
-                                                        Membership,
-                                                        Connections0),
-
-                    %% Gossip.
-                    do_gossip(Membership, Connections),
-
-                    {reply, ok, State#state{membership=Merged,
-                                            connections=Connections}};
+                    {reply, ok, State#state{membership=Membership}};
                 false ->
                     %% Remove state.
                     delete_state_from_disk(),
 
                     %% Shutdown; connections terminated on shutdown.
-                    {stop, normal, State#state{membership=Membership}}
+                    {stop, normal, State}
             end
     end;
 handle_message({forward_message, ServerRef, Message}, State) ->
@@ -465,30 +451,28 @@ schedule_gossip() ->
 do_gossip(Membership, Connections) ->
     Fanout = partisan_config:get(fanout, ?FANOUT),
 
-    case get_peers(Membership) of
-        [] ->
-            ok;
-        AllPeers ->
-            {ok, Peers} = random_peers(AllPeers, Fanout),
-            lists:foreach(fun(Peer) ->
-                        do_send_message(Peer,
-                                        {receive_state, Membership},
-                                        Connections)
-                end, Peers),
-            ok
-    end.
+    ActualMembership = membership(Membership, Connections),
+    lager:info("M ~p, C ~p, A ~p", [Membership, Connections, ActualMembership]),
+    Peers = [Name || {Name, _, _} <- ActualMembership, Name /= node()],
+    PeersFanout = random_peers(Peers, Fanout),
+
+    lists:foreach(
+        fun(Peer) ->
+            do_send_message(
+                Peer,
+                {receive_state, Membership},
+                Connections
+            )
+        end,
+        PeersFanout
+    ).
 
 %% @private
-get_peers(Local) ->
-    Members = members(Local),
-    Peers = [X || {X, _, _} <- Members, X /= node()],
-    Peers.
-
-%% @private
+-spec random_peers(list(node()), non_neg_integer()) ->
+    list(node()).
 random_peers(Peers, Fanout) ->
     Shuffled = shuffle(Peers),
-    Peer = lists:sublist(Shuffled, Fanout),
-    {ok, Peer}.
+    lists:sublist(Shuffled, Fanout).
 
 %% @private
 do_send_message(Name, Message, Connections) ->
@@ -517,3 +501,24 @@ down(Name, #state{down_functions=DownFunctions}) ->
             [Function() || Function <- Functions],
             ok
     end.
+
+%% @private
+-spec membership(membership(), connections()) -> list(node_spec()).
+membership(Membership, Connections) ->
+    lists:filter(
+        fun({Name, _, _}) ->
+            case dict:find(Name, Connections) of
+                {ok, undefined} ->
+                    false;
+                {ok, _Pid} ->
+                    true;
+                error ->
+                    false
+            end
+        end,
+        to_list(Membership)
+    ).
+
+%% @private
+schedule_reconnect() ->
+    timer:send_after(?RECONNECT_INTERVAL, reconnect).

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -286,6 +286,7 @@ handle_info({connected, _Node, _Tag, RemoteState},
                       connections=Connections}=State) ->
 
     %% Update membership by joining with remote membership.
+    lager:info("connected BF ~p", [RemoteState]),
     Membership = ?SET:merge(RemoteState, Membership0),
     persist_state(Membership),
 
@@ -417,6 +418,7 @@ handle_message({receive_state, PeerMembership},
             {reply, ok, State};
         false ->
             %% Merge data items.
+            lager:info("receive_state BF ~p", [PeerMembership]),
             Membership = ?SET:merge(PeerMembership, Membership0),
 
             %% Persist state.

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -360,7 +360,7 @@ handle_call({receive_message, Message}, _From, State) ->
 
 handle_call(members, _From, #state{myself=Myself,
                                    active=Active}=State) ->
-    lager:info("Node ~p active view: ~p", [Myself, members(Active)]),
+    %lager:info("Node ~p active view: ~p", [Myself, members(Active)]),
     ActiveMembers = [P || {P, _, _} <- members(Active)],
     {reply, {ok, ActiveMembers}, State};
 

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -358,9 +358,7 @@ handle_call({receive_message, Message}, _From, State) ->
     gen_server:cast(?MODULE, {receive_message, Message}),
     {reply, ok, State};
 
-handle_call(members, _From, #state{myself=Myself,
-                                   active=Active}=State) ->
-    %lager:info("Node ~p active view: ~p", [Myself, members(Active)]),
+handle_call(members, _From, #state{active=Active}=State) ->
     ActiveMembers = [P || {P, _, _} <- members(Active)],
     {reply, {ok, ActiveMembers}, State};
 

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -1014,8 +1014,7 @@ maybe_connect({Name, _, _} = Node, Connections0) ->
                                               Connections0),
                     {Result, Connections1};
                 {error, normal} ->
-                    lager:info("Node ~p failed connection: ~p.",
-                               [Node]),
+                    lager:info("Node ~p failed connection.", [Node]),
                     Result = ok,
                     Connections1 = dict:store(Name,
                                               undefined,

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -255,9 +255,22 @@ handle_call(partitions, _From, #state{partitions=Partitions}=State) ->
 handle_call({leave, _Node}, _From, State) ->
     {reply, error, State};
 
-handle_call({join, {_Name, _, _}=Node}, _From, State) ->
-    gen_server:cast(?MODULE, {join, Node}),
-    {reply, ok, State};
+handle_call({join, {_Name, _, _}=Peer}, _From,
+            #state{myself=Myself0,
+                   tag=Tag0,
+                   connections=Connections0,
+                   epoch=Epoch0}=State0) ->
+    %% Trigger connection.
+    {Result, Connections} = maybe_connect(Peer, Connections0),
+
+    lager:info("Node ~p sends the JOIN message to ~p", [Myself0, Peer]),
+    %% Send the JOIN message to the peer.
+    do_send_message(Peer,
+                    {join, Myself0, Tag0, Epoch0},
+                    Connections),
+
+    %% Return.
+    {reply, Result, State0#state{connections=Connections}};
 
 handle_call({resolve_partition, Reference}, _From, State) ->
     Partitions = handle_partition_resolution(Reference, State),
@@ -362,23 +375,6 @@ handle_call(Msg, _From, State) ->
 %% @private
 -spec handle_cast(term(), state_t()) -> {noreply, state_t()}.
 
-handle_cast({join, Peer},
-            #state{myself=Myself0,
-                   tag=Tag0,
-                   connections=Connections0,
-                   epoch=Epoch0}=State0) ->
-    %% Trigger connection.
-    Connections = maybe_connect(Peer, Connections0),
-
-    lager:info("Node ~p sends the JOIN message to ~p", [Myself0, Peer]),
-    %% Send the JOIN message to the peer.
-    do_send_message(Peer,
-                    {join, Myself0, Tag0, Epoch0},
-                    Connections),
-
-    %% Return.
-    {noreply, State0#state{connections=Connections}};
-
 handle_cast({receive_message, Message}, State0) ->
     handle_message(Message, State0);
 
@@ -444,7 +440,7 @@ handle_info(passive_view_maintenance,
                     State0;
                 Random ->
                     %% Trigger connection.
-                    Connections = maybe_connect(Random, Connections0),
+                    {_, Connections} = maybe_connect(Random, Connections0),
 
                     %% Forward shuffle request.
                     do_send_message(Random,
@@ -570,7 +566,7 @@ handle_message({join, Peer, PeerTag, PeerEpoch},
             State1 = add_to_active_view(Peer, PeerTag, State0),
 
             %% Establish connections.
-            Connections1 = maybe_connect(Peer, Connections0),
+            {_, Connections1} = maybe_connect(Peer, Connections0),
 
             LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
             %% Send the NEIGHBOR message to origin, that will update it's view.
@@ -584,7 +580,7 @@ handle_message({join, Peer, PeerTag, PeerEpoch},
             Connections = lists:foldl(
               fun(P, AccConnections0) ->
                   %% Establish connections.
-                  AccConnections = maybe_connect(Peer, AccConnections0),
+                  {_, AccConnections} = maybe_connect(Peer, AccConnections0),
 
                   do_send_message(
                       P,
@@ -616,7 +612,7 @@ handle_message({neighbor, Peer, PeerTag, DisconnectId, _Sender},
     State = case is_addable(DisconnectId, Peer, SentMessageMap0) of
                 true ->
                     %% Establish connections.
-                    Connections = maybe_connect(Peer, Connections0),
+                    {_, Connections} = maybe_connect(Peer, Connections0),
 
                     %% Add node into the active view.
                     add_to_active_view(
@@ -656,7 +652,7 @@ handle_message({forward_join, Peer, PeerTag, PeerEpoch, TTL, Sender},
                     State1 = add_to_active_view(Peer, PeerTag, State0),
 
                     %% Establish connections.
-                    Connections1 = maybe_connect(Peer, Connections0),
+                    {_, Connections1} = maybe_connect(Peer, Connections0),
 
                     LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
                     %% Send neighbor message to origin, that will update it's view.
@@ -692,7 +688,7 @@ handle_message({forward_join, Peer, PeerTag, PeerEpoch, TTL, Sender},
                             State3 = add_to_active_view(Peer, PeerTag, State2),
 
                             %% Establish connections.
-                            Connections3 = maybe_connect(Peer, Connections0),
+                            {_, Connections3} = maybe_connect(Peer, Connections0),
 
                             LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
                             %% Send neighbor message to origin, that will
@@ -708,7 +704,7 @@ handle_message({forward_join, Peer, PeerTag, PeerEpoch, TTL, Sender},
                     end;
                 Random ->
                     %% Establish any new connections.
-                    Connections2 = maybe_connect(Random, Connections0),
+                    {_, Connections2} = maybe_connect(Random, Connections0),
 
                     %% Forward join.
                     do_send_message(
@@ -780,7 +776,7 @@ handle_message({neighbor_request, Peer, Priority, PeerTag, DisconnectId, Exchang
                [Myself0, Peer, DisconnectId]),
 
     %% Establish connections.
-    Connections = maybe_connect(Peer, Connections0),
+    {_, Connections} = maybe_connect(Peer, Connections0),
 
     Exchange_Ack0 = %% Myself.
                     [Myself0] ++
@@ -884,7 +880,7 @@ handle_message({shuffle, Exchange, TTL, Sender},
                              State0;
                          Random ->
                              %% Trigger connection.
-                             Connections1 = maybe_connect(Random, Connections0),
+                             {_, Connections1} = maybe_connect(Random, Connections0),
 
                              %% Forward shuffle until random walk complete.
                              do_send_message(Random,
@@ -901,7 +897,7 @@ handle_message({shuffle, Exchange, TTL, Sender},
                                                      length(Exchange)),
 
             %% Trigger connection.
-            Connections2 = maybe_connect(Sender, Connections0),
+            {_, Connections2} = maybe_connect(Sender, Connections0),
 
             do_send_message(Sender,
                             {shuffle_reply, ResponseExchange, Myself},
@@ -993,39 +989,42 @@ members(Set) ->
 %% socket pid if they are connected.
 %%
 maybe_connect({Name, _, _} = Node, Connections0) ->
-    Connections = case dict:find(Name, Connections0) of
+    ShouldConnect = case dict:find(Name, Connections0) of
         %% Found in dict, and disconnected.
         {ok, undefined} ->
             lager:info("Node ~p is not connected; initiating.", [Node]),
-
-            case connect(Node) of
-                {ok, Pid} ->
-                    lager:info("Node ~p connected.", [Node]),
-                    dict:store(Name, Pid, Connections0);
-                Error ->
-                    lager:info("Node ~p failed connection: ~p.", [Node, Error]),
-                    dict:store(Name, undefined, Connections0)
-            end;
+            true;
         %% Found in dict and connected.
-        {ok, Pid} ->
-            dict:store(Name, Pid, Connections0);
+        {ok, _Pid} ->
+            false;
         %% Not present; disconnected.
         error ->
             lager:info("Node ~p never was connected; initiating.", [Node]),
+            true
+    end,
 
+    case ShouldConnect of
+        true ->
             case connect(Node) of
                 {ok, Pid} ->
                     lager:info("Node ~p connected.", [Node]),
-                    dict:store(Name, Pid, Connections0);
+                    Result = ok,
+                    Connections1 = dict:store(Name,
+                                              Pid,
+                                              Connections0),
+                    {Result, Connections1};
                 {error, normal} ->
-                    lager:info("Node ~p isn't online just yet.", [Node]),
-                    dict:store(Name, undefined, Connections0);
-                Error ->
-                    lager:info("Node ~p failed connection: ~p.", [Node, Error]),
-                    dict:store(Name, undefined, Connections0)
-            end
-    end,
-    Connections.
+                    lager:info("Node ~p failed connection: ~p.",
+                               [Node]),
+                    Result = ok,
+                    Connections1 = dict:store(Name,
+                                              undefined,
+                                              Connections0),
+                    {Result, Connections1}
+            end;
+        false ->
+            {ok, Connections0}
+    end.
 
 %% @private
 connect(Node) ->

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -1219,7 +1219,7 @@ drop_random_element_from_active_view(
                                         State0#state{active=Active}),
 
             %% Trigger connection.
-            Connections1 = maybe_connect(Peer, Connections0),
+            {_, Connections1} = maybe_connect(Peer, Connections0),
 
             %% Get next disconnect id for the peer.
             NextId = get_next_id(Peer, Epoch0, SentMessageMap0),
@@ -1417,7 +1417,7 @@ move_random_peer_from_passive_to_active(
             Exchange = lists:usort(Exchange0),
 
             %% Trigger connection.
-            Connections = maybe_connect(Random, Connections0),
+            {_, Connections} = maybe_connect(Random, Connections0),
 
             LastDisconnectId = get_current_id(Random, RecvMessageMap0),
             do_send_message(

--- a/src/partisan_peer_service.erl
+++ b/src/partisan_peer_service.erl
@@ -22,9 +22,6 @@
 -module(partisan_peer_service).
 
 -export([join/1,
-         join/2,
-         join/3,
-         attempt_join/1,
          leave/1,
          decode/1,
          stop/0,
@@ -41,22 +38,9 @@ manager() ->
                         partisan_default_peer_service_manager).
 
 %% @doc prepare node to join a cluster
-join(Node) ->
-    join(Node, true).
-
-%% @doc Convert nodename to atom
-join(NodeStr, Auto) when is_list(NodeStr) ->
-    join(erlang:list_to_atom(lists:flatten(NodeStr)), Auto);
-join(Node, Auto) when is_atom(Node) ->
-    join(node(), Node, Auto);
-join({_Name, _IPAddress, _Port} = Node, _Auto) ->
-    attempt_join(Node).
-
-%% @doc Initiate join. Nodes cannot join themselves.
-join(Node, Node, _) ->
-    {error, self_join};
-join(_, Node, _Auto) ->
-    attempt_join(Node).
+join({_Name, _IPAddress, _Port} = Node) ->
+    Manager = manager(),
+    Manager:join(Node).
 
 %% @doc Return cluster members.
 members() ->
@@ -71,11 +55,6 @@ add_sup_callback(Function) ->
 decode(State) ->
     Manager = manager(),
     [P || {P, _, _} <- Manager:decode(State)].
-
-%% @private
-attempt_join({_Name, _, _}=Node) ->
-    Manager = manager(),
-    Manager:join(Node).
 
 %% @doc Attempt to leave the cluster.
 leave(_Args) when is_list(_Args) ->

--- a/src/partisan_peer_service_client.erl
+++ b/src/partisan_peer_service_client.erl
@@ -48,7 +48,7 @@
 %%%===================================================================
 
 %% @doc Start and link to calling process.
--spec start_link(node_spec(), pid()) -> {ok, pid()} | ignore | {error, term()}.
+-spec start_link(node_spec(), pid()) -> {ok, pid()} | ignore | error().
 start_link(Peer, From) ->
     gen_server:start_link(?MODULE, [Peer, From], []).
 

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -31,7 +31,7 @@
 
 -callback get_local_state() -> term().
 
--callback join(node_spec()) -> ok.
+-callback join(node_spec()) -> ok | {error, term()}.
 -callback leave() -> ok.
 -callback leave(node_spec()) -> ok.
 

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -25,13 +25,13 @@
 
 -export([myself/0]).
 
--callback start_link() -> {ok, pid()} | ignore | {error, term()}.
+-callback start_link() -> {ok, pid()} | ignore | error().
 -callback members() -> [name()].
 -callback myself() -> node_spec().
 
 -callback get_local_state() -> term().
 
--callback join(node_spec()) -> ok | {error, term()}.
+-callback join(node_spec()) -> ok | error().
 -callback leave() -> ok.
 -callback leave(node_spec()) -> ok.
 

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -362,14 +362,16 @@ do_send_message(Name, Message, Connections) ->
 membership(Membership, Connections) ->
     lists:filter(
         fun({Name, _, _}) ->
-            case dict:find(Name, Connections) of
+            Connected = case dict:find(Name, Connections) of
                 {ok, undefined} ->
                     false;
                 {ok, _Pid} ->
                     true;
                 error ->
                     false
-            end
+            end,
+
+            Connected orelse Name == node()
         end,
         sets:to_list(Membership)
     ).

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -221,6 +221,7 @@ handle_info({'EXIT', From, _Reason}, #state{connections=Connections0}=State) ->
                       end
               end,
     Connections = dict:fold(FoldFun, Connections0, Connections0),
+    lager:info("FROM ~p, Connections0 ~p, Connections ~p\n\n", [From, Connections0, Connections]),
     {noreply, State#state{connections=Connections}};
 
 handle_info({connected, Node, _Tag, _RemoteState},

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -223,7 +223,7 @@ handle_info({'EXIT', From, _Reason}, #state{connections=Connections0,
                 % Remove from membership
                 MembershipAcc1 = sets:filter(
                     fun({Name, _, _}) ->
-                        Name /= V
+                        Name /= K
                     end,
                     MembershipAcc0
                 ),

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -238,8 +238,13 @@ handle_info({'EXIT', From, _Reason}, #state{connections=Connections0,
             {Connections0, Membership0},
             Connections0
     ),
+
     lager:info("FROM ~p, Connections0 ~p, Connections ~p\n\n", [From, dict:to_list(Connections0), dict:to_list(Connections)]),
     lager:info("Membership0 ~p, Membership ~p\n\n", [sets:to_list(Membership0), sets:to_list(Membership)]),
+
+    %% Announce to the peer service.
+    partisan_peer_service_events:update(Membership),
+
     {noreply, State#state{connections=Connections,
                           membership=Membership}};
 

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -177,7 +177,7 @@ handle_call({join, {Name, _, _}=Node},
 
     %% Return.
     {reply, Result, State#state{pending=Pending,
-                            connections=Connections}};
+                                connections=Connections}};
 
 handle_call({send_message, Name, Message}, _From,
             #state{connections=Connections}=State) ->

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -229,8 +229,6 @@ handle_info({'EXIT', From, _Reason}, #state{membership=Membership,
     end,
     Connections = dict:fold(FoldFun, Connections0, Connections0),
 
-    lager:info("FROM ~p, Connections0 ~p, Connections ~p\n\n", [From, dict:to_list(Connections0), dict:to_list(Connections)]),
-
     %% Announce to the peer service.
     ActualMembership = membership(Membership, Connections),
     partisan_peer_service_events:update(ActualMembership),

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -219,9 +219,12 @@ handle_info(reconnect, #state{membership=Membership,
 handle_info({'EXIT', From, _Reason}, #state{membership=Membership,
                                             connections=Connections0}=State) ->
 
+    lager:info("EXIT received"),
+
     FoldFun = fun(K, V, AccIn) ->
         case V =:= From of
             true ->
+                lager:info("EXIT received from ~p\n\n", [K]),
                 dict:store(K, undefined, AccIn);
             false ->
                 AccIn

--- a/src/partisan_sup.erl
+++ b/src/partisan_sup.erl
@@ -39,11 +39,12 @@ start_link() ->
 init([]) ->
     partisan_config:init(),
 
-    Manager = partisan_config:get(partisan_peer_service_manager),
-
     Children = lists:flatten(
                  [
-                 ?CHILD(Manager, worker),
+                 ?CHILD(partisan_default_peer_service_manager, worker),
+                 ?CHILD(partisan_client_server_peer_service_manager, worker),
+                 ?CHILD(partisan_static_peer_service_manager, worker),
+                 ?CHILD(partisan_hyparview_peer_service_manager, worker),
                  ?CHILD(partisan_peer_service_events, worker)
                  ]),
 

--- a/src/partisan_sup.erl
+++ b/src/partisan_sup.erl
@@ -39,12 +39,11 @@ start_link() ->
 init([]) ->
     partisan_config:init(),
 
+    Manager = partisan_config:get(partisan_peer_service_manager),
+
     Children = lists:flatten(
                  [
-                 ?CHILD(partisan_default_peer_service_manager, worker),
-                 ?CHILD(partisan_client_server_peer_service_manager, worker),
-                 ?CHILD(partisan_static_peer_service_manager, worker),
-                 ?CHILD(partisan_hyparview_peer_service_manager, worker),
+                 ?CHILD(Manager, worker),
                  ?CHILD(partisan_peer_service_events, worker)
                  ]),
 

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -21,7 +21,11 @@
 
 -module(partisan_util).
 
--export([build_tree/3]).
+-include("partisan.hrl").
+
+-export([build_tree/3,
+         establish_connections/3,
+         maybe_connect/2]).
 
 %% @doc Convert a list of elements into an N-ary tree. This conversion
 %%      works by treating the list as an array-based tree where, for
@@ -47,3 +51,63 @@ build_tree(N, Nodes, Opts) ->
                             {NewResult, Rest}
                     end, {[], tl(Expand)}, Nodes),
     orddict:from_list(Tree).
+
+%% @doc Reconnect disconnected members and members waiting to join.
+-spec establish_connections(pending(), [node_spec()], connections()) -> connections().
+establish_connections(Pending, Members, Connections) ->
+    AllPeers = lists:keydelete(node(), 1, Members ++ Pending),
+    lists:foldl(
+        fun(Peer, Acc) ->
+            {_Result, Connections} = maybe_connect(Peer, Acc),
+            Connections
+        end,
+        Connections,
+        AllPeers
+    ).
+
+%% @doc Function should enforce the invariant that all cluster
+%%      members are keys in the dict pointing to undefined if they
+%%      are disconnected or a socket pid if they are connected. 
+-spec maybe_connect(node_spec(), connections()) -> {ok | error(), connections()}.
+maybe_connect({Name, _, _} = Node, Connections0) ->
+    ShouldConnect = case dict:find(Name, Connections0) of
+        %% Found in dict, and disconnected.
+        {ok, undefined} ->
+            lager:info("Node ~p is not connected; initiating.", [Node]),
+            true;
+        %% Found in dict and connected.
+        {ok, _Pid} ->
+            lager:info("Node ~p is already connect.", [Node]),
+            false;
+        %% Not present; disconnected.
+        error ->
+            lager:info("Node ~p never was connected; initiating.", [Node]),
+            true
+    end,
+
+    case ShouldConnect of
+        true ->
+            case connect(Node) of
+                {ok, Pid} ->
+                    lager:info("Node ~p connected.", [Node]),
+                    Result = ok,
+                    Connections1 = dict:store(Name,
+                                              Pid,
+                                              Connections0),
+                    {Result, Connections1};
+                _ ->
+                    lager:info("Node ~p failed connection.", [Node]),
+                    Result = {error, undefined},
+                    Connections1 = dict:store(Name,
+                                              undefined,
+                                              Connections0),
+                    {Result, Connections1}
+            end;
+        false ->
+            {ok, Connections0}
+    end.
+
+%% @private
+connect(Node) ->
+    Self = self(),
+    partisan_peer_service_client:start_link(Node, Self).

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -55,8 +55,8 @@ build_tree(N, Nodes, Opts) ->
 %% @doc Reconnect disconnected members and members waiting to join.
 -spec establish_connections(pending(), [node_spec()], connections()) -> connections().
 establish_connections(Pending, Members, Connections0) ->
-    Myself = partisan_peer_service_manager:myself(),
-    AllPeers = lists:keydelete(Myself, 1, Members ++ Pending),
+    {MyName, _, _} = partisan_peer_service_manager:myself(),
+    AllPeers = lists:keydelete(MyName, 1, Members ++ Pending),
     lists:foldl(
         fun(Peer, Acc) ->
             {_Result, Connections} = maybe_connect(Peer, Acc),

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -89,8 +89,6 @@ maybe_connect({Name, _, _} = Node, Connections0) ->
     end,
 
     ShouldConnect = ShouldConnect0 andalso Name /= node(),
-    lager:info("SC0 ~p, SC ~p, Name ~p, node() ~p\n\n", [ShouldConnect0, ShouldConnect, Name, node()]),
-
 
     case ShouldConnect of
         true ->

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -73,22 +73,26 @@ establish_connections(Membership, Connections) ->
 %%      (even if undefined).
 -spec maybe_connect(node_spec(), connections()) -> {ok | error(), connections()}.
 maybe_connect({Name, _, _} = Node, Connections0) ->
-    ShouldConnect0 = case dict:find(Name, Connections0) of
+    ShouldConnect = case dict:find(Name, Connections0) of
         %% Found in dict, and disconnected.
         {ok, undefined} ->
             lager:info("Node ~p is not connected; initiating.", [Node]),
             true;
         %% Found in dict and connected.
         {ok, _Pid} ->
-            lager:info("Node ~p is already connect.", [Node]),
+            %lager:info("Node ~p is already connect.", [Node]),
             false;
-        %% Not present; disconnected.
+        %% Not present; never connected.
         error ->
-            lager:info("Node ~p never was connected; initiating.", [Node]),
-            true
+            Should = Name /= node(),
+            case Should of
+                true ->
+                    lager:info("Node ~p never was connected; initiating.", [Node]);
+                false ->
+                    ok
+            end,
+            Should
     end,
-
-    ShouldConnect = ShouldConnect0 andalso Name /= node(),
 
     case ShouldConnect of
         true ->

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -67,7 +67,7 @@ establish_connections(Pending, Members, Connections) ->
 
 %% @doc Function should enforce the invariant that all cluster
 %%      members are keys in the dict pointing to undefined if they
-%%      are disconnected or a socket pid if they are connected. 
+%%      are disconnected or a socket pid if they are connected.
 -spec maybe_connect(node_spec(), connections()) -> {ok | error(), connections()}.
 maybe_connect({Name, _, _} = Node, Connections0) ->
     ShouldConnect = case dict:find(Name, Connections0) of

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -73,7 +73,7 @@ establish_connections(Membership, Connections) ->
 %%      (even if undefined).
 -spec maybe_connect(node_spec(), connections()) -> {ok | error(), connections()}.
 maybe_connect({Name, _, _} = Node, Connections0) ->
-    ShouldConnect = case dict:find(Name, Connections0) of
+    ShouldConnect0 = case dict:find(Name, Connections0) of
         %% Found in dict, and disconnected.
         {ok, undefined} ->
             lager:info("Node ~p is not connected; initiating.", [Node]),
@@ -87,6 +87,8 @@ maybe_connect({Name, _, _} = Node, Connections0) ->
             lager:info("Node ~p never was connected; initiating.", [Node]),
             true
     end,
+
+    ShoulConnect = ShouldConnect0 andalso Name /= node(),
 
     case ShouldConnect of
         true ->

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -88,7 +88,9 @@ maybe_connect({Name, _, _} = Node, Connections0) ->
             true
     end,
 
-    ShoulConnect = ShouldConnect0 andalso Name /= node(),
+    ShouldConnect = ShouldConnect0 andalso Name /= node(),
+    lager:info("SC0 ~p, SC ~p, Name ~p, node() ~p\n\n", [ShouldConnect0, ShouldConnect, Name, node()]),
+
 
     case ShouldConnect of
         true ->

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -55,7 +55,8 @@ build_tree(N, Nodes, Opts) ->
 %% @doc Reconnect disconnected members and members waiting to join.
 -spec establish_connections(pending(), [node_spec()], connections()) -> connections().
 establish_connections(Pending, Members, Connections) ->
-    AllPeers = lists:keydelete(node(), 1, Members ++ Pending),
+    Myself = partisan_peer_service_manager:myself(),
+    AllPeers = lists:keydelete(Myself, 1, Members ++ Pending),
     lists:foldl(
         fun(Peer, Acc) ->
             {_Result, Connections} = maybe_connect(Peer, Acc),

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -54,7 +54,7 @@ build_tree(N, Nodes, Opts) ->
 
 %% @doc Reconnect disconnected members and members waiting to join.
 -spec establish_connections(pending(), [node_spec()], connections()) -> connections().
-establish_connections(Pending, Members, Connections) ->
+establish_connections(Pending, Members, Connections0) ->
     Myself = partisan_peer_service_manager:myself(),
     AllPeers = lists:keydelete(Myself, 1, Members ++ Pending),
     lists:foldl(
@@ -62,7 +62,7 @@ establish_connections(Pending, Members, Connections) ->
             {_Result, Connections} = maybe_connect(Peer, Acc),
             Connections
         end,
-        Connections,
+        Connections0,
         AllPeers
     ).
 

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -42,7 +42,7 @@
 -define(APP, partisan).
 -define(CLIENT_NUMBER, 3).
 -define(PEER_PORT, 9000).
--define(WAIT_TIME, 2000). %% 2 seconds
+-define(WAIT_TIME, 1000). %% 1 second
 
 %% ===================================================================
 %% common_test callbacks
@@ -114,12 +114,16 @@ default_manager_test(Config) ->
     %% Use the default peer service manager.
     Manager = partisan_default_peer_service_manager,
 
+    %% Specify servers.
+    Servers = node_list(1, "server", Config),
+
     %% Specify clients.
     Clients = node_list(?CLIENT_NUMBER, "client", Config),
 
     %% Start nodes.
     Nodes = start(default_manager_test, Config,
                   [{partisan_peer_service_manager, Manager},
+                   {servers, Servers},
                    {clients, Clients}]),
 
     %% Pause for clustering.


### PR DESCRIPTION
- [x] If `partisan_peer_connection:connect` fails, return `{error, undefined}` when calling `manager:join`:
   - [x] default manager
   - [x] static manager
   - [x] client-server manager
   - [x] hyparview manager
- [x] Refactor `maybe_connect/2` and `establish_connections/2`
- [x] Add static manager test
- [x] Reconnect to disconnected peers from time to time
- [x] Since on `EXIT`, a peer is removed from `connections`, a peer is member if in membership and with an active connection
- [x] Remove `pending` list since `connections` can be used for that
- [x] Always persist state to disk when membership changes