### PR TITLE
Zl/type fix and leave

### DIFF
--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -183,10 +183,10 @@ handle_call({leave, Node}, _From,
                    membership=Membership0}=State) ->
     %% Node may exist in the membership on multiple ports, so we need to
     %% remove all.
-    Membership = lists:foldl(fun({N, _, _}, L0) ->
+    Membership = lists:foldl(fun({Name, _, _} = N, L0) ->
                         case Node of
-                            N ->
-                                {ok, L} = ?SET:mutate({rmv, Node}, Actor, L0),
+                            Name ->
+                                {ok, L} = ?SET:mutate({rmv, N}, Actor, L0),
                                 L;
                             _ ->
                                 L0

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -56,7 +56,7 @@
 -define(SET, state_orset).
 
 -type pending() :: [node_spec()].
--type membership() :: ?SET:orswot().
+-type membership() :: ?SET:state_orset().
 -type tag() :: atom().
 
 -record(state, {actor :: actor(),

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -180,10 +180,10 @@ handle_call({leave, Node}, _From,
                    membership=Membership0}=State) ->
     %% Node may exist in the membership on multiple ports, so we need to
     %% remove all.
-    Membership = lists:foldl(fun({N, _, _}, L0) ->
+    Membership = lists:foldl(fun({Name, _, _} = N, L0) ->
                         case Node of
-                            N ->
-                                {ok, L} = ?SET:mutate({rmv, Node}, Actor, L0),
+                            Name ->
+                                {ok, L} = ?SET:mutate({rmv, N}, Actor, L0),
                                 L;
                             _ ->
                                 L0

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -55,7 +55,7 @@
 -define(SET, state_orset).
 
 -type pending() :: [node_spec()].
--type membership() :: ?SET:orswot().
+-type membership() :: ?SET:state_orset().
 
 -record(state, {actor :: actor(),
                 pending :: pending(),


### PR DESCRIPTION
Updates types (orswot -> state_orset) and makes sure `leave` actually removes node from the cluster.