### PR TITLE
Generate coverage report at the end of ct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ eunit:
 
 ct:
 	openssl rand -out test/partisan_SUITE_data/RAND 4096
-	${REBAR} as test ct
+	${REBAR} ct
+	${REBAR} cover
 
 shell:
 	${REBAR} shell --apps partisan


### PR DESCRIPTION
No need for `rebar3 as test ct`, the test profile is implicit when running common test as documented in https://www.rebar3.org/docs/profiles