### PR TITLE
Try connect to peer before sending FORWARD_JOIN

### DIFF
--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -584,7 +584,7 @@ handle_message({join, Peer, PeerTag, PeerEpoch},
             Connections = lists:foldl(
               fun(P, AccConnections0) ->
                   %% Establish connections.
-                  AccConnections = maybe_connect(Peer, AccConnections0),
+                  AccConnections = maybe_connect(P, AccConnections0),
 
                   do_send_message(
                       P,


### PR DESCRIPTION
While joining a new node on the contact node, try
and connect to all nodes in the active view before
sending the FORWARD_JOIN message