### PR TITLE
Drop duplicate manager() methods

### DIFF
--- a/src/partisan_peer_service_console.erl
+++ b/src/partisan_peer_service_console.erl
@@ -26,7 +26,7 @@
 -include("partisan.hrl").
 
 members([]) ->
-    Manager = manager(),
+    Manager = partisan_peer_service:manager(),
     {ok, Members} = Manager:members(),
     print_members(Members).
 
@@ -37,7 +37,3 @@ print_members(Members) ->
     _ = io:format("~79..=s~n", [""]),
     ok.
 
-%% @private
-manager() ->
-    partisan_config:get(partisan_peer_service_manager,
-                        partisan_default_peer_service_manager).

--- a/src/partisan_peer_service_events.erl
+++ b/src/partisan_peer_service_events.erl
@@ -71,7 +71,7 @@ update(LocalState) ->
 %% ===================================================================
 
 init([Fn]) ->
-    Manager = manager(),
+    Manager = partisan_peer_service:manager(),
     {ok, LocalState} = Manager:get_local_state(),
     try
         Fn(LocalState)
@@ -101,8 +101,3 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-%% @private
-manager() ->
-    partisan_config:get(partisan_peer_service_manager,
-                        partisan_default_peer_service_manager).

--- a/src/partisan_peer_service_server.erl
+++ b/src/partisan_peer_service_server.erl
@@ -111,7 +111,7 @@ handle_message({hello, Node},
         ok ->
             %% Send our state to the remote service, incase they want
             %% it to bootstrap.
-            Manager = manager(),
+            Manager = partisan_peer_service:manager(),
             {ok, LocalState} = Manager:get_local_state(),
             send_message(Socket, {state, Tag, LocalState}),
             ok;
@@ -121,7 +121,7 @@ handle_message({hello, Node},
             ok
     end;
 handle_message(Message, _State) ->
-    Manager = manager(),
+    Manager = partisan_peer_service:manager(),
     Manager:receive_message(Message),
     ok.
 
@@ -152,7 +152,3 @@ maybe_connect_disterl(Node) ->
             ok
     end.
 
-%% @private
-manager() ->
-    partisan_config:get(partisan_peer_service_manager,
-                        partisan_default_peer_service_manager).


### PR DESCRIPTION
Use a single one defined in partisan_peer_service.