### PR TITLE
Refactor connections dictionary

### DIFF
--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -4,9 +4,9 @@
 -define(PEER_SERVICE_SERVER, partisan_peer_service_server).
 -define(FANOUT, 5).
 -define(CACHE, partisan_connection_cache).
+-define(PARALLELISM, 1).
 
 -type actor() :: binary().
--type connections() :: dict:dict(node(), port()).
 -type node_spec() :: {node(), inet:ip_address(), non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -80,7 +80,7 @@
                 passive :: passive(),
                 reserved :: reserved(),
                 tag :: tag(),
-                connections :: connections(),
+                connections :: partisan_peer_service_connections:t(),
                 max_active_size :: non_neg_integer(),
                 min_active_size :: non_neg_integer(),
                 max_passive_size :: non_neg_integer(),
@@ -198,7 +198,7 @@ init([]) ->
     process_flag(trap_exit, true),
 
     {Active, Passive, Epoch} = maybe_load_state_from_disk(),
-    Connections = dict:new(),
+    Connections = partisan_peer_service_connections:new(),
     Myself = myself(),
 
     SentMessageMap = dict:new(),
@@ -373,7 +373,7 @@ handle_cast({join, Peer},
                    connections=Connections0,
                    epoch=Epoch0}=State0) ->
     %% Trigger connection.
-    Connections = maybe_connect(Peer, Connections0),
+    Connections = partisan_util:maybe_connect(Peer, Connections0),
 
     lager:info("Node ~p sends the JOIN message to ~p", [Myself0, Peer]),
     %% Send the JOIN message to the peer.
@@ -452,7 +452,7 @@ handle_info(passive_view_maintenance,
                     State0;
                 Random ->
                     %% Trigger connection.
-                    Connections = maybe_connect(Random, Connections0),
+                    Connections = partisan_util:maybe_connect(Random, Connections0),
 
                     %% Forward shuffle request.
                     do_send_message(Random,
@@ -475,19 +475,7 @@ handle_info({'EXIT', From, Reason},
     lager:info("connection pid ~p died due to ~p",
                [From, Reason]),
     %% Prune active connections from dictionary.
-    FoldFun = fun(K, V, {Peer, AccIn}) ->
-                      case V =:= From of
-                          true ->
-                              %% This *should* only ever match one.
-                              AccOut = dict:store(K, undefined, AccIn),
-                              {K, AccOut};
-                          false ->
-                              {Peer, AccIn}
-                      end
-              end,
-    {Peer, Connections} = dict:fold(FoldFun,
-                                    {undefined, Connections0},
-                                    Connections0),
+    {Peer, Connections} = partisan_peer_service_connections:prune(From, Connections0),
 
     %% If it was in the passive view and our connection attempt failed,
     %% remove from the passive view altogether.
@@ -535,14 +523,19 @@ handle_info(Msg, State) ->
 %% @private
 -spec terminate(term(), state_t()) -> term().
 terminate(_Reason, #state{connections=Connections}=_State) ->
-    dict:map(fun(_K, Pid) ->
-                     try
-                         gen_server:stop(Pid, normal, infinity)
-                     catch
-                         _:_ ->
-                             ok
-                     end
-             end, Connections),
+    Fun =
+        fun(_K, Pids) ->
+            lists:foreach(
+              fun(Pid) ->
+                 try
+                     gen_server:stop(Pid, normal, infinity)
+                 catch
+                     _:_ ->
+                         ok
+                 end
+              end, Pids)
+         end,
+    partisan_peer_service_connections:foreach(Fun, Connections),
     ok.
 
 %% @private
@@ -584,7 +577,7 @@ handle_message({join, Peer, PeerTag, PeerEpoch},
             State1 = add_to_active_view(Peer, PeerTag, State0),
 
             %% Establish connections.
-            Connections1 = maybe_connect(Peer, State1#state.connections),
+            Connections1 = partisan_util:maybe_connect(Peer, State1#state.connections),
 
             LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
             %% Send the NEIGHBOR message to origin, that will update it's view.
@@ -602,7 +595,7 @@ handle_message({join, Peer, PeerTag, PeerEpoch},
             Connections = lists:foldl(
               fun(P, AccConnections0) ->
                   %% Establish connections.
-                  AccConnections = maybe_connect(P, AccConnections0),
+                  AccConnections = partisan_util:maybe_connect(P, AccConnections0),
 
                   lager:info("Forwarding join of ~p to active view peer ~p",
                              [Peer, P]),
@@ -640,7 +633,7 @@ handle_message({neighbor, Peer, PeerTag, DisconnectId, _Sender},
     State = case is_addable(DisconnectId, Peer, SentMessageMap0) of
                 true ->
                     %% Establish connections.
-                    Connections = maybe_connect(Peer, Connections0),
+                    Connections = partisan_util:maybe_connect(Peer, Connections0),
 
                     %% Add node into the active view.
                     State1 = add_to_active_view(
@@ -685,7 +678,7 @@ handle_message({forward_join, Peer, PeerTag, PeerEpoch, TTL, Sender},
                     State1 = add_to_active_view(Peer, PeerTag, State0),
 
                     %% Establish connections.
-                    Connections1 = maybe_connect(Peer, State1#state.connections),
+                    Connections1 = partisan_util:maybe_connect(Peer, State1#state.connections),
 
                     LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
                     %% Send neighbor message to origin, that will update it's view.
@@ -728,7 +721,7 @@ handle_message({forward_join, Peer, PeerTag, PeerEpoch, TTL, Sender},
                             State3 = add_to_active_view(Peer, PeerTag, State2),
 
                             %% Establish connections.
-                            Connections3 = maybe_connect(Peer, State3#state.connections),
+                            Connections3 = partisan_util:maybe_connect(Peer, State3#state.connections),
 
                             LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
                             %% Send neighbor message to origin, that will
@@ -749,7 +742,7 @@ handle_message({forward_join, Peer, PeerTag, PeerEpoch, TTL, Sender},
                     end;
                 Random ->
                     %% Establish any new connections.
-                    Connections2 = maybe_connect(Random, Connections0),
+                    Connections2 = partisan_util:maybe_connect(Random, Connections0),
 
                     lager:info("FORWARD_JOIN: forwarding to ~p",
                                [Random]),
@@ -830,7 +823,7 @@ handle_message({neighbor_request, Peer, Priority, PeerTag, DisconnectId, Exchang
                [Myself0, Peer, DisconnectId]),
 
     %% Establish connections.
-    Connections = maybe_connect(Peer, Connections0),
+    Connections = partisan_util:maybe_connect(Peer, Connections0),
 
     Exchange_Ack0 = %% Myself.
                     [Myself0] ++
@@ -947,7 +940,7 @@ handle_message({shuffle, Exchange, TTL, Sender},
                              State0;
                          Random ->
                              %% Trigger connection.
-                             Connections1 = maybe_connect(Random, Connections0),
+                             Connections1 = partisan_util:maybe_connect(Random, Connections0),
 
                              %% Forward shuffle until random walk complete.
                              do_send_message(Random,
@@ -964,7 +957,7 @@ handle_message({shuffle, Exchange, TTL, Sender},
                                                      length(Exchange)),
 
             %% Trigger connection.
-            Connections2 = maybe_connect(Sender, Connections0),
+            Connections2 = partisan_util:maybe_connect(Sender, Connections0),
 
             do_send_message(Sender,
                             {shuffle_reply, ResponseExchange, Myself},
@@ -1051,91 +1044,52 @@ members(Set) ->
     sets:to_list(Set).
 
 %% @private
-%% Function should enforce the invariant that all cluster members are
-%% keys in the dict pointing to undefined if they are disconnected or a
-%% socket pid if they are connected.
-%%
-maybe_connect({Name, _, _} = Node, Connections0) ->
-    Connections = case dict:find(Name, Connections0) of
-        %% Found in dict, and disconnected.
-        {ok, undefined} ->
-            lager:info("Node ~p is not connected; initiating.", [Node]),
-
-            case connect(Node) of
-                {ok, Pid} ->
-                    lager:info("Node ~p connected.", [Node]),
-                    dict:store(Name, Pid, Connections0);
-                Error ->
-                    lager:info("Node ~p failed connection: ~p.", [Node, Error]),
-                    dict:store(Name, undefined, Connections0)
-            end;
-        %% Found in dict and connected.
-        {ok, Pid} ->
-            dict:store(Name, Pid, Connections0);
-        %% Not present; disconnected.
-        error ->
-            lager:info("Node ~p never was connected; initiating.", [Node]),
-
-            case connect(Node) of
-                {ok, Pid} ->
-                    lager:info("Node ~p connected.", [Node]),
-                    dict:store(Name, Pid, Connections0);
-                {error, normal} ->
-                    lager:info("Node ~p isn't online just yet.", [Node]),
-                    dict:store(Name, undefined, Connections0);
-                Error ->
-                    lager:info("Node ~p failed connection: ~p.", [Node, Error]),
-                    dict:store(Name, undefined, Connections0)
-            end
-    end,
-    Connections.
-
-%% @private
-connect(Node) ->
-    Self = self(),
-    partisan_peer_service_client:start_link(Node, Self).
-
-%% @private
-disconnect(Name, Connections) ->
+-spec disconnect(Node :: node_spec(),
+                 Connections :: partisan_peer_service_connections:t()) ->
+            partisan_peer_service_connections:t().
+disconnect(Node, Connections0) ->
     %% Find a connection for the remote node, if we have one.
-    case dict:find(Name, Connections) of
-        {ok, undefined} ->
+    case partisan_peer_service_connections:find(Node, Connections0) of
+        {ok, []} ->
             %% Return original set.
-            Connections;
-        {ok, Pid} ->
+            Connections0;
+        {ok, [Pid|_]} ->
             %% Stop;
             lager:info("disconnecting node ~p by stopping connection pid ~p",
-                       [Name, Pid]),
+                       [Node, Pid]),
             gen_server:stop(Pid),
 
             %% Null out in the dictionary.
-            dict:store(Name, undefined, Connections);
-        error ->
+            {_, Connections} =  partisan_peer_service_connections:prune(Node, Connections0),
+            Connections;
+        {error, not_found} ->
             %% Return original set.
-            Connections
+            Connections0
     end.
 
 %% @private
-do_send_message(Name, Message, Connections) when is_atom(Name) ->
+-spec do_send_message(Node :: atom() | node_spec(),
+                      Message :: term(),
+                      Connections :: partisan_peer_service_connections:t()) ->
+            {error, disconnected} | {error, not_yet_connected} | {error, term()} | ok.
+do_send_message(Node, Message, Connections) ->
     %% Find a connection for the remote node, if we have one.
-    case dict:find(Name, Connections) of
-        {ok, undefined} ->
+    case partisan_peer_service_connections:find(Node, Connections) of
+        {ok, []} ->
             %% Node was connected but is now disconnected.
             {error, disconnected};
-        {ok, Pid} ->
+        {ok, [Pid|_]} ->
             try
                 gen_server:call(Pid, {send_message, Message})
             catch
                 Reason:Error ->
-                    lager:info("failed to send a message to ~p due to ~p:~p", [Name, Reason, Error]),
+                    lager:info("failed to send a message to ~p due to ~p:~p", [Node, Reason, Error]),
                     {error, Error}
             end;
-        error ->
+        {error, not_found} ->
             %% Node has not been connected yet.
             {error, not_yet_connected}
-    end;
-do_send_message({Name, _, _}, Message, Connections) ->
-    do_send_message(Name, Message, Connections).
+    end.
 
 %% @private
 select_random(View, Omit) ->
@@ -1285,7 +1239,7 @@ drop_random_element_from_active_view(
                                         State0#state{active=Active}),
 
             %% Trigger connection.
-            Connections1 = maybe_connect(Peer, Connections0),
+            Connections1 = partisan_util:maybe_connect(Peer, Connections0),
 
             %% Get next disconnect id for the peer.
             NextId = get_next_id(Peer, Epoch0, SentMessageMap0),
@@ -1481,7 +1435,7 @@ move_peer_from_passive_to_active(Peer,
     Exchange = lists:usort(Exchange0),
 
     %% Trigger connection.
-    Connections = maybe_connect(Peer, Connections0),
+    Connections = partisan_util:maybe_connect(Peer, Connections0),
 
     LastDisconnectId = get_current_id(Peer, RecvMessageMap0),
     do_send_message(

--- a/src/partisan_peer_service_connections.erl
+++ b/src/partisan_peer_service_connections.erl
@@ -1,0 +1,155 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2017 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc API for managing peer service connections
+-module(partisan_peer_service_connections).
+
+-export([
+         new/0,
+         find/2,
+         store/3,
+         prune/2,
+         foreach/2]).
+
+-include("partisan.hrl").
+
+-type t() :: dict:dict(node_spec(), list(pid())).
+-export_type([t/0]).
+
+%% @doc Creates a new dictionary of connections.
+-spec new() -> t().
+new() ->
+    dict:new().
+
+%% @doc Finds connection pids in dictionary either by name or node spec.
+-spec find(Node :: atom() | node_spec(),
+           Connections :: t()) -> {ok, list(pid())} | {error, not_found}.
+find(Name, Connections) when is_atom(Name) ->
+    find_first_name(Name, dict:to_list(Connections));
+find(Node, Connections) ->
+    case dict:find(Node, Connections) of
+        error -> {error, not_found};
+        {ok, Pids} -> {ok, Pids}
+    end.
+
+%% @doc Store a connection pid
+-spec store(Node :: node_spec(),
+            Pid :: undefined | pid(),
+            Connections :: t()) -> t().
+store(Node, Pid0, Connections) ->
+    Pid = case Pid0 of
+            undefined -> [];
+            _ -> [Pid0]
+          end,
+    case find(Node, Connections) of
+        {error, not_found} ->
+            dict:store(Node, Pid, Connections);
+        _ ->
+            dict:fold(fun(Node0, Pids, ConnectionsIn) when Node0 =:= Node ->
+                            dict:store(Node, Pids ++ Pid, ConnectionsIn);
+                         (_Node, _Pids, ConnectionsIn) -> ConnectionsIn
+                      end, Connections, Connections)
+    end.
+
+%% @doc Prune all occurrences of a connection pid
+%%      returns the node where the pruned pid was found
+-spec prune(pid() | node_spec(),
+            Connections :: t()) -> {node_spec(), t()}.
+prune({_, _, _} = Node, Connections) ->
+    {Node, dict:store(Node, [], Connections)};
+prune(Pid, Connections) ->
+    dict:fold(fun(Node, Pids, {AccNode, ConnectionsIn}) ->
+                    case lists:member(Pid, Pids) of
+                        true ->
+                            {Node,
+                             dict:store(Node, lists:subtract(Pids, [Pid]), ConnectionsIn)};
+                        false ->
+                            {AccNode, ConnectionsIn}
+                    end
+              end, {undefined, Connections}, Connections).
+
+%% @doc Apply a function to all connection entries
+-spec foreach(Fun :: fun((node_spec(), list(pid())) -> ok),
+              Connections :: t()) -> ok.
+foreach(Fun, Connections) ->
+    dict:map(Fun, Connections),
+    ok.
+
+%% @private
+-spec find_first_name(Name :: atom(),
+                      ConnectionsList :: [{node_spec(), list(pid())}]) ->
+            {ok, list(pid())} | {error, not_found}.
+find_first_name(_Name, []) -> {error, not_found};
+find_first_name(Name, [{{Name, _, _}, Pids}|_]) -> {ok, Pids};
+find_first_name(Name, [_|Rest]) -> find_first_name(Name, Rest).
+
+%%
+%% Tests
+%%
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+no_connections_test() ->
+    Connections0 = new(),
+    ?assertEqual({error, not_found}, find(node1, Connections0)).
+
+one_connection_test() ->
+    Connections0 = new(),
+    Connections1 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections0),
+    ?assertEqual({ok, [self()]}, find({node1, {127, 0, 0, 1}, 80}, Connections1)),
+    Connections2 = store({node2, {127, 0, 0, 1}, 81}, self(), Connections1),
+    ?assertEqual({ok, [self()]}, find(node2, Connections2)).
+
+several_connections_test() ->
+    Connections0 = new(),
+    Connections1 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections0),
+    Connections2 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections1),
+    ?assertEqual({ok, [self(), self()]}, find({node1, {127, 0, 0, 1}, 80}, Connections2)),
+    ?assertEqual({ok, [self(), self()]}, find(node1, Connections2)).
+
+prune_connections_test() ->
+    Connections0 = new(),
+    Connections1 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections0),
+    Connections2 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections1),
+    ?assertEqual({ok, [self(), self()]}, find({node1, {127, 0, 0, 1}, 80}, Connections2)),
+    {{node1, {127, 0, 0, 1}, 80}, Connections3} = prune(self(), Connections2),
+    ?assertEqual({ok, [self()]}, find({node1, {127, 0, 0, 1}, 80}, Connections3)),
+    {{node1, {127, 0, 0, 1}, 80}, Connections4} = prune(self(), Connections3),
+    ?assertEqual({ok, []}, find({node1, {127, 0, 0, 1}, 80}, Connections4)),
+    Connections5 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections4),
+    Connections6 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections5),
+    {{node1, {127, 0, 0, 1}, 80}, Connections7} = prune(self(), Connections6),
+    ?assertEqual({ok, [self()]}, find(node1, Connections7)),
+    {{node1, {127, 0, 0, 1}, 80}, Connections8} = prune(self(), Connections7),
+    ?assertEqual({ok, []}, find(node1, Connections8)).
+
+add_remove_add_connection_test() ->
+    Connections0 = new(),
+    Connections1 = store({node1, {127, 0, 0, 1}, 80}, self(), Connections0),
+    ?assertEqual({ok, [self()]}, find(node1, Connections1)),
+    {{node1, {127, 0, 0, 1}, 80}, Connections2} = prune(self(), Connections1),
+    ?assertEqual({ok, []}, find(node1, Connections2)),
+    Connections3 = store({node1, {127, 0, 0, 1}, 81}, self(), Connections2),
+    ?assertEqual({ok, [self()]}, find(node1, Connections3)),
+    {{node1, {127, 0, 0, 1}, 81}, Connections4} = prune({node1, {127, 0, 0, 1}, 81}, Connections3),
+    ?assertEqual({ok, []}, find(node1, Connections4)).
+
+-endif.

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -59,7 +59,7 @@
 -record(state, {myself :: node_spec(),
                 pending :: pending(),
                 membership :: membership(),
-                connections :: connections()}).
+                connections :: partisan_peer_service_connections:t()}).
 
 -type state_t() :: #state{}.
 
@@ -152,7 +152,7 @@ init([]) ->
     process_flag(trap_exit, true),
 
     Membership = maybe_load_state_from_disk(),
-    Connections = dict:new(),
+    Connections = partisan_peer_service_connections:new(),
     Myself = myself(),
 
     {ok, #state{myself=Myself,
@@ -180,7 +180,7 @@ handle_call({join, {Name, _, _}=Node},
     Pending = [Node|Pending0],
 
     %% Trigger connection.
-    Connections = maybe_connect(Node, Connections0),
+    Connections = partisan_util:maybe_connect(Node, Connections0),
 
     %% Return.
     {reply, ok, State#state{pending=Pending,
@@ -219,15 +219,7 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info({'EXIT', From, _Reason}, #state{connections=Connections0}=State) ->
-    FoldFun = fun(K, V, AccIn) ->
-                      case V =:= From of
-                          true ->
-                              dict:store(K, undefined, AccIn);
-                          false ->
-                              AccIn
-                      end
-              end,
-    Connections = dict:fold(FoldFun, Connections0, Connections0),
+    {_, Connections} = partisan_peer_service_connections:prune(From, Connections0),
     {noreply, State#state{connections=Connections}};
 
 handle_info({connected, Node, _Tag, _RemoteState},
@@ -271,14 +263,19 @@ handle_info(Msg, State) ->
 %% @private
 -spec terminate(term(), state_t()) -> term().
 terminate(_Reason, #state{connections=Connections}=_State) ->
-    dict:map(fun(_K, Pid) ->
-                     try
-                         gen_server:stop(Pid, normal, infinity)
-                     catch
-                         _:_ ->
-                             ok
-                     end
-             end, Connections),
+    Fun =
+        fun(_K, Pids) ->
+            lists:foreach(
+              fun(Pid) ->
+                 try
+                     gen_server:stop(Pid, normal, infinity)
+                 catch
+                     _:_ ->
+                         ok
+                 end
+              end, Pids)
+         end,
+    partisan_peer_service_connections:foreach(Fun, Connections),
     ok.
 
 %% @private
@@ -345,57 +342,26 @@ establish_connections(Pending, Membership, Connections) ->
     %% Reconnect disconnected members and members waiting to join.
     Members = members(Membership),
     AllPeers = lists:keydelete(node(), 1, Members ++ Pending),
-    lists:foldl(fun maybe_connect/2, Connections, AllPeers).
-
-%% @private
-%%
-%% Function should enforce the invariant that all cluster members are
-%% keys in the dict pointing to undefined if they are disconnected or a
-%% socket pid if they are connected.
-%%
-maybe_connect({Name, _, _} = Node, Connections0) ->
-    Connections = case dict:find(Name, Connections0) of
-        %% Found in dict, and disconnected.
-        {ok, undefined} ->
-            case connect(Node) of
-                {ok, Pid} ->
-                    dict:store(Name, Pid, Connections0);
-                _ ->
-                    dict:store(Name, undefined, Connections0)
-            end;
-        %% Found in dict and connected.
-        {ok, _Pid} ->
-            Connections0;
-        %% Not present; disconnected.
-        error ->
-            case connect(Node) of
-                {ok, Pid} ->
-                    dict:store(Name, Pid, Connections0);
-                _ ->
-                    dict:store(Name, undefined, Connections0)
-            end
-    end,
-    Connections.
-
-%% @private
-connect(Node) ->
-    Self = self(),
-    partisan_peer_service_client:start_link(Node, Self).
+    lists:foldl(fun partisan_util:maybe_connect/2, Connections, AllPeers).
 
 handle_message({forward_message, ServerRef, Message}, State) ->
     gen_server:cast(ServerRef, Message),
     {reply, ok, State}.
 
 %% @private
-do_send_message(Name, Message, Connections) ->
+-spec do_send_message(Node :: node_spec(),
+                      Message :: term(),
+                      Connections :: partisan_peer_service_connections:t()) ->
+            {error, disconnected} | {error, not_yet_connected} | {error, term()} | ok.
+do_send_message(Node, Message, Connections) ->
     %% Find a connection for the remote node, if we have one.
-    case dict:find(Name, Connections) of
-        {ok, undefined} ->
+    case partisan_peer_service_connections:find(Node, Connections) of
+        {ok, []} ->
             %% Node was connected but is now disconnected.
             {error, disconnected};
-        {ok, Pid} ->
+        {ok, [Pid|_]} ->
             gen_server:cast(Pid, {send_message, Message});
-        error ->
+        {error, not_found} ->
             %% Node has not been connected yet.
             {error, not_yet_connected}
     end.

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -21,7 +21,10 @@
 
 -module(partisan_util).
 
--export([build_tree/3]).
+-include("partisan.hrl").
+
+-export([build_tree/3,
+         maybe_connect/2, maybe_connect/3]).
 
 %% @doc Convert a list of elements into an N-ary tree. This conversion
 %%      works by treating the list as an array-based tree where, for
@@ -47,3 +50,85 @@ build_tree(N, Nodes, Opts) ->
                             {NewResult, Rest}
                     end, {[], tl(Expand)}, Nodes),
     orddict:from_list(Tree).
+
+%% @doc Create a new connection to a node and return a new dictionary
+%%      with the associated connect pid
+%%
+%%      Function should enforce the invariant that all cluster members are
+%%      keys in the dict pointing to empty list if they are disconnected or a
+%%      socket pid if they are connected.
+%%
+-spec maybe_connect(Node :: node_spec(),
+                    Connections :: partisan_peer_service_connections:t()) ->
+            partisan_peer_service_connections:t().
+maybe_connect(Node, Connections0) ->
+    maybe_connect(Node, Connections0, dict:new()).
+
+-spec maybe_connect(Node :: node_spec(),
+                    Connections :: partisan_peer_service_connections:t(),
+                    MemberParallelism :: dict:dict()) ->
+            partisan_peer_service_connections:t().
+maybe_connect(Node, Connections, MemberParallelism) ->
+    %% Compute desired parallelism.
+    Parallelism  = case dict:find(Node, MemberParallelism) of
+        {ok, V} ->
+            %% We learned about a node via an explicit join.
+            V;
+        error ->
+            %% We learned about a node through a state merge; assume the
+            %% default unless later specified.
+            partisan_config:get(parallelism, ?PARALLELISM)
+    end,
+
+    %% Initiate connections.
+    case partisan_peer_service_connections:find(Node, Connections) of
+        %% Found disconnected.
+        {ok, []} ->
+            lager:info("Node ~p is not connected; initiating.", [Node]),
+            case connect(Node) of
+                {ok, Pid} ->
+                    lager:info("Node ~p connected.", [Node]),
+                    partisan_peer_service_connections:store(Node, Pid, Connections);
+                Error ->
+                    lager:info("Node ~p failed connection: ~p.", [Node, Error]),
+                    partisan_peer_service_connections:store(Node, undefined, Connections)
+            end;
+        %% Found and connected.
+        {ok, Pids} ->
+            case length(Pids) < Parallelism andalso Parallelism =/= undefined of
+                true ->
+                    lager:info("(~p of ~p) Connecting node ~p.",
+                               [length(Pids), Parallelism, Node]),
+
+                    case connect(Node) of
+                        {ok, Pid} ->
+                            lager:info("Node connected with ~p", [Pid]),
+                            partisan_peer_service_connections:store(Node, Pid, Connections);
+                        Error ->
+                            lager:info("Node failed connect with ~p", [Error]),
+                            partisan_peer_service_connections:store(Node, undefined, Connections)
+                    end;
+                false ->
+                    Connections
+            end;
+        %% Not present; disconnected.
+        {error, not_found} ->
+            case connect(Node) of
+                {ok, Pid} ->
+                    lager:info("Node ~p connected.", [Node]),
+                    partisan_peer_service_connections:store(Node, Pid, Connections);
+                {error, normal} ->
+                    lager:info("Node ~p isn't online just yet.", [Node]),
+                    partisan_peer_service_connections:store(Node, undefined, Connections);
+                Error ->
+                    lager:info("Node ~p failed connection: ~p.", [Node, Error]),
+                    partisan_peer_service_connections:store(Node, undefined, Connections)
+            end
+    end.
+
+%% @private
+-spec connect(Node :: node_spec()) -> {ok, pid()} | ignore | {error, term()}.
+connect(Node) ->
+    Self = self(),
+    partisan_peer_service_client:start_link(Node, Self).
+

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -832,8 +832,8 @@ check_forward_message(Node, Manager) ->
     ct:pal("requesting node ~p to forward message to store_proc on node ~p",
            [Node, RandomMember]),
     Rand = rand_compat:uniform(),
-    rpc:call(Node, Manager, forward_message,
-             [RandomMember, store_proc, {store, Rand}]),
+    ok = rpc:call(Node, Manager, forward_message,
+                  [RandomMember, store_proc, {store, Rand}]),
     %% now fetch the value from the random destination node
     ok = wait_until(fun() ->
                     %% it must match with what we asked the node to forward

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -312,14 +312,14 @@ hyparview_manager_partition_test(Config) ->
     case wait_until(CheckStartedFun, 60 * 2, 100) of
         ok ->
             ok;
-        {fail, {connected_check_failed, Nodes}} ->
+        {fail, {false, {connected_check_failed, Nodes}}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p",
                     [Nodes]);
-        {fail, {symmetry_check_failed, Nodes}} ->
+        {fail, {false, {symmetry_check_failed, Nodes}}} ->
             ct:fail("Symmetry is broken (ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [Nodes]);
-        {fail, [{connected_check_failed, ConnectedFails},
-                {symmetry_check_failed, SymmetryFails}]} ->
+        {fail, {false, [{connected_check_failed, ConnectedFails},
+                        {symmetry_check_failed, SymmetryFails}]}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p, symmetry is broken as well"
                     "(ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [ConnectedFails, SymmetryFails])
@@ -414,14 +414,14 @@ hyparview_manager_high_active_test(Config) ->
     case wait_until(CheckStartedFun, 60 * 2, 100) of
         ok ->
             ok;
-        {fail, {connected_check_failed, Nodes}} ->
+        {fail, {false, {connected_check_failed, Nodes}}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p",
                     [Nodes]);
-        {fail, {symmetry_check_failed, Nodes}} ->
+        {fail, {false, {symmetry_check_failed, Nodes}}} ->
             ct:fail("Symmetry is broken (ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [Nodes]);
-        {fail, [{connected_check_failed, ConnectedFails},
-                {symmetry_check_failed, SymmetryFails}]} ->
+        {fail, {false, [{connected_check_failed, ConnectedFails},
+                        {symmetry_check_failed, SymmetryFails}]}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p, symmetry is broken as well"
                     "(ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [ConnectedFails, SymmetryFails])
@@ -470,14 +470,14 @@ hyparview_manager_low_active_test(Config) ->
     case wait_until(CheckStartedFun, 60 * 2, 100) of
         ok ->
             ok;
-        {fail, {connected_check_failed, Nodes}} ->
+        {fail, {false, {connected_check_failed, Nodes}}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p",
                     [Nodes]);
-        {fail, {symmetry_check_failed, Nodes}} ->
+        {fail, {false, {symmetry_check_failed, Nodes}}} ->
             ct:fail("Symmetry is broken (ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [Nodes]);
-        {fail, [{connected_check_failed, ConnectedFails},
-                {symmetry_check_failed, SymmetryFails}]} ->
+        {fail, {false, [{connected_check_failed, ConnectedFails},
+                        {symmetry_check_failed, SymmetryFails}]}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p, symmetry is broken as well"
                     "(ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [ConnectedFails, SymmetryFails])
@@ -524,14 +524,14 @@ hyparview_manager_high_client_test(Config) ->
     case wait_until(CheckStartedFun, 60 * 2, 100) of
         ok ->
             ok;
-        {fail, {connected_check_failed, Nodes}} ->
+        {fail, {false, {connected_check_failed, Nodes}}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p",
                     [Nodes]);
-        {fail, {symmetry_check_failed, Nodes}} ->
+        {fail, {false, {symmetry_check_failed, Nodes}}} ->
             ct:fail("Symmetry is broken (ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [Nodes]);
-        {fail, [{connected_check_failed, ConnectedFails},
-                {symmetry_check_failed, SymmetryFails}]} ->
+        {fail, {false, [{connected_check_failed, ConnectedFails},
+                        {symmetry_check_failed, SymmetryFails}]}} ->
             ct:fail("Graph is not connected, unable to find route between pairs of nodes ~p, symmetry is broken as well"
                     "(ie. node1 has node2 in it's view but vice-versa is not true) between the following "
                     "pairs of nodes: ~p", [ConnectedFails, SymmetryFails])


### PR DESCRIPTION
This is a continuation of the discussion in #54 and supersedes the changes in that PR.
Peer Manager connections are now abstracted in the `partisan_peer_service_connections` module, it currently only offers `new/0` and `find/2`. It this change looks ok, following PRs will contain the remaining methods of the abstraction.

Store a three tuple node_spec() in connections
dictionary as key instead of a node name atom.
Introduce new module that abstracts away the
peer service connections dictionary.