### PR TITLE
Only consider active view members on forward join

### DIFF
--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -584,7 +584,10 @@ handle_message({join, Peer, PeerTag, PeerEpoch},
                             Connections1),
 
             %% Random walk for forward join.
-            Peers = members(Active0) -- [Myself0],
+            %% Since we might have dropped peers from the active view when
+            %% adding this one we need to use the most up to date active view,
+            %% and that's the one that's currently in the state
+            Peers = members(State1#state.active) -- [Myself0],
 
             Connections = lists:foldl(
               fun(P, AccConnections0) ->


### PR DESCRIPTION
Fix the case where, on join, a  member is dropped
from the active view and therefore should not be
considered when forwarding joins.
The initial active view was being used instead of
the one that resulted from a possible removal.

