### PR TITLE
Ensure we force connection immediately.

### DIFF
--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -206,7 +206,9 @@ handle_call({leave, Node}, _From,
 
 handle_call({join, {Name, _, _}=Node},
             _From,
-            #state{pending=Pending0, connections=Connections0}=State) ->
+            #state{pending=Pending0,
+                   membership=Membership,
+                   connections=Connections0}=State) ->
     %% Attempt to join via disterl for control messages during testing.
     _ = net_kernel:connect(Name),
 
@@ -214,7 +216,7 @@ handle_call({join, {Name, _, _}=Node},
     Pending = [Node|Pending0],
 
     %% Trigger connection.
-    Connections = maybe_connect(Node, Connections0),
+    Connections = establish_connections(Pending, Membership, Connections0),
 
     %% Return.
     {reply, ok, State#state{pending=Pending,


### PR DESCRIPTION
Resolve an issue in the default connection manager where a new join request would not be connected immediately.