### PR TITLE
Fix connection cache

### DIFF
--- a/src/partisan_connection_cache.erl
+++ b/src/partisan_connection_cache.erl
@@ -26,10 +26,12 @@
 -export([update/1,
          dispatch/1]).
 
+-spec update(partisan_peer_service_connections:t()) ->
+            partisan_peer_service_connections:t().
 update(Connections) ->
     ets:delete_all_objects(?CACHE),
 
-    dict:fold(fun(K, V, _AccIn) ->
+    dict:fold(fun({K, _, _}, V, _AccIn) ->
                       true = ets:insert(?CACHE, [{K, V}])
               end, [], Connections).
 

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -1057,23 +1057,25 @@ members(Set) ->
             partisan_peer_service_connections:t().
 disconnect(Node, Connections0) ->
     %% Find a connection for the remote node, if we have one.
-    case partisan_peer_service_connections:find(Node, Connections0) of
-        {ok, []} ->
-            %% Return original set.
-            Connections0;
-        {ok, [Pid|_]} ->
-            %% Stop;
-            lager:info("disconnecting node ~p by stopping connection pid ~p",
-                       [Node, Pid]),
-            gen_server:stop(Pid),
+    Connections =
+        case partisan_peer_service_connections:find(Node, Connections0) of
+            {ok, []} ->
+                %% Return original set.
+                Connections0;
+            {ok, [Pid|_]} ->
+                %% Stop;
+                lager:info("disconnecting node ~p by stopping connection pid ~p",
+                           [Node, Pid]),
+                gen_server:stop(Pid),
 
-            %% Null out in the dictionary.
-            {_, Connections} =  partisan_peer_service_connections:prune(Node, Connections0),
-            Connections;
-        {error, not_found} ->
-            %% Return original set.
-            Connections0
-    end.
+                %% Null out in the dictionary.
+                {_, Connections1} =  partisan_peer_service_connections:prune(Node, Connections0),
+                Connections1;
+            {error, not_found} ->
+                %% Return original set.
+                Connections0
+        end,
+    Connections.
 
 %% @private
 -spec do_send_message(Node :: atom() | node_spec(),

--- a/src/partisan_sup.erl
+++ b/src/partisan_sup.erl
@@ -38,13 +38,11 @@ start_link() ->
 
 init([]) ->
     partisan_config:init(),
+    Manager = partisan_peer_service:manager(),
 
     Children = lists:flatten(
                  [
-                 ?CHILD(partisan_default_peer_service_manager, worker),
-                 ?CHILD(partisan_client_server_peer_service_manager, worker),
-                 ?CHILD(partisan_static_peer_service_manager, worker),
-                 ?CHILD(partisan_hyparview_peer_service_manager, worker),
+                 ?CHILD(Manager, worker),
                  ?CHILD(partisan_peer_service_events, worker)
                  ]),
 


### PR DESCRIPTION
684f01f2bfe86c9d4baf33a21b6d96c147fb532c fixes clobbering of the cache by other managers.
0faddba6ea078d63047eca07f25fdb82338a21ed gets the cache to actually be used as it was just trapping to `gen_server:call` all the time.