### PR TITLE
Allow multiple bind addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Partisan has many available peer service managers:
 * Full membership with TCP-based failure detection: `plumtree_default_peer_service_manager.`
 * Client/server topology: `plumtree_client_server_peer_service_manager.`
 * HyParView, hybrid partial view membership protocol, with TCP-based failure detection: `plumtree_hyparview_peer_service_manager.`
+

--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -7,7 +7,7 @@
 -define(PARALLELISM, 1).
 
 -type actor() :: binary().
--type node_spec() :: {node(), inet:ip_address(), non_neg_integer()}.
+-type node_spec() :: #{name => node(), ip => inet:ip_address(), port => non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().
 -type partitions() :: [{reference(), node_spec()}].

--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -1,15 +1,16 @@
 -define(APP, partisan).
--define(PEER_IP, {127,0,0,1}).
+-define(PEER_IP, {127, 0, 0, 1}).
 -define(PEER_PORT, 9000).
+-define(LISTEN_ADDRS, [#{ip => ?PEER_IP, port => ?PEER_PORT}]).
 -define(PEER_SERVICE_SERVER, partisan_peer_service_server).
 -define(FANOUT, 5).
 -define(CACHE, partisan_connection_cache).
 -define(PARALLELISM, 1).
 
 -type actor() :: binary().
+-type listen_addr() :: #{ip => inet:ip_address(), port => non_neg_integer()}.
 -type node_spec() :: #{name => node(),
-                       ip => inet:ip_address(),
-                       port => non_neg_integer(),
+                       listen_addrs => [listen_addr()],
                        parallelism => non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().

--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -7,7 +7,10 @@
 -define(PARALLELISM, 1).
 
 -type actor() :: binary().
--type node_spec() :: #{name => node(), ip => inet:ip_address(), port => non_neg_integer()}.
+-type node_spec() :: #{name => node(),
+                       ip => inet:ip_address(),
+                       port => non_neg_integer(),
+                       parallelism => non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().
 -type partitions() :: [{reference(), node_spec()}].

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -178,7 +178,7 @@ handle_call({leave, Node}, _From,
             #state{membership=Membership0}=State) ->
     %% Node may exist in the membership on multiple ports, so we need to
     %% remove all.
-    Membership = lists:foldl(fun({Name, _, _} = N, L0) ->
+    Membership = lists:foldl(fun(#{name := Name} = N, L0) ->
                         case Node of
                             Name ->
                                 sets:del_element(N, Membership0);
@@ -198,7 +198,7 @@ handle_call({leave, Node}, _From,
             {reply, ok, State}
     end;
 
-handle_call({join, {Name, _, _}=Node},
+handle_call({join, #{name := Name}=Node},
             _From,
             #state{pending=Pending0, connections=Connections0}=State) ->
     %% Attempt to join via disterl for control messages during testing.
@@ -230,7 +230,7 @@ handle_call({receive_message, Message}, _From, State) ->
     handle_message(Message, State);
 
 handle_call(members, _From, #state{membership=Membership}=State) ->
-    Members = [P || {P, _, _} <- members(Membership)],
+    Members = [P || #{name := P} <- members(Membership)],
     {reply, {ok, Members}, State};
 
 handle_call(get_local_state, _From, #state{membership=Membership}=State) ->
@@ -395,7 +395,14 @@ members(Membership) ->
 establish_connections(Pending, Membership, Connections) ->
     %% Reconnect disconnected members and members waiting to join.
     Members = members(Membership),
-    AllPeers = lists:keydelete(node(), 1, Members ++ Pending),
+    AllPeers = lists:filter(fun(#{name := Name}) ->
+                         case node() of
+                             Name ->
+                                 false;
+                             _ ->
+                                 true
+                         end
+                 end, Members ++ Pending),
     lists:foldl(fun partisan_util:maybe_connect/2, Connections, AllPeers).
 
 handle_message({forward_message, ServerRef, Message}, State) ->

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -304,7 +304,7 @@ terminate(_Reason, #state{connections=Connections}=_State) ->
     Fun =
         fun(_K, Pids) ->
             lists:foreach(
-              fun(Pid) ->
+              fun({_ListenAddr, Pid}) ->
                  try
                      gen_server:stop(Pid, normal, infinity)
                  catch
@@ -420,7 +420,8 @@ do_send_message(Node, Message, Connections) ->
         {ok, []} ->
             %% Node was connected but is now disconnected.
             {error, disconnected};
-        {ok, [Pid|_]} ->
+        {ok, Entries} ->
+            {_ListenAddr, Pid} = lists:nth(rand_compat:uniform(length(Entries)), Entries),
             gen_server:cast(Pid, {send_message, Message});
         {error, not_found} ->
             %% Node has not been connected yet.

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -80,6 +80,7 @@ init() ->
                            {partisan_peer_service_manager, PeerService},
                            {peer_ip, IPAddress},
                            {peer_port, PeerPort},
+                           {listen_addrs, [#{ip => IPAddress, port => PeerPort}]},
                            {random_promotion, true},
                            {reservations, []},
                            {tls, false},
@@ -105,15 +106,12 @@ set(Key, Value) ->
     application:set_env(?APP, Key, Value),
     partisan_mochiglobal:put(Key, Value).
 
+listen_addrs() ->
+    partisan_config:get(listen_addrs, ?LISTEN_ADDRS).
+
 %% @private
 random_port() ->
     {ok, Socket} = gen_tcp:listen(0, []),
     {ok, {_, Port}} = inet:sockname(Socket),
     ok = gen_tcp:close(Socket),
     Port.
-
-listen_addrs() ->
-    PeerIP = partisan_config:get(peer_ip),
-    PeerPort = partisan_config:get(peer_port),
-    ListenAddrs = partisan_config:get(listen_addrs, []),
-    lists:flatten([{default, PeerIP, PeerPort}] ++ ListenAddrs).

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -77,7 +77,6 @@ init() ->
                            {max_active_size, 6},
                            {max_passive_size, 30},
                            {min_active_size, 3},
-                           {parallelism, 1},
                            {partisan_peer_service_manager, PeerService},
                            {peer_ip, IPAddress},
                            {peer_port, PeerPort},

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -117,4 +117,4 @@ listen_addrs() ->
     PeerIP = partisan_config:get(peer_ip),
     PeerPort = partisan_config:get(peer_port),
     ListenAddrs = partisan_config:get(listen_addrs, []),
-    lists:flatten([{PeerIP, PeerPort}] ++ ListenAddrs).
+    lists:flatten([{default, PeerIP, PeerPort}] ++ ListenAddrs).

--- a/src/partisan_connection_cache.erl
+++ b/src/partisan_connection_cache.erl
@@ -42,6 +42,6 @@ dispatch({forward_message, Name, ServerRef, Message}) ->
             %% Trap back to gen_server.
             {error, trap};
         [{Name, Pids}] ->
-            Pid = lists:nth(rand_compat:uniform(length(Pids)), Pids),
+            {_ListenAddr, Pid} = lists:nth(rand_compat:uniform(length(Pids)), Pids),
             gen_server:cast(Pid, {send_message, {forward_message, ServerRef, Message}})
     end.

--- a/src/partisan_connection_cache.erl
+++ b/src/partisan_connection_cache.erl
@@ -31,8 +31,8 @@
 update(Connections) ->
     ets:delete_all_objects(?CACHE),
 
-    dict:fold(fun(K, V, _AccIn) ->
-                      true = ets:insert(?CACHE, [{K, V}])
+    dict:fold(fun(#{name := Name}, V, _AccIn) ->
+                      true = ets:insert(?CACHE, [{Name, V}])
               end, [], Connections).
 
 dispatch({forward_message, Name, ServerRef, Message}) ->

--- a/src/partisan_connection_cache.erl
+++ b/src/partisan_connection_cache.erl
@@ -31,7 +31,7 @@
 update(Connections) ->
     ets:delete_all_objects(?CACHE),
 
-    dict:fold(fun({K, _, _}, V, _AccIn) ->
+    dict:fold(fun(K, V, _AccIn) ->
                       true = ets:insert(?CACHE, [{K, V}])
               end, [], Connections).
 

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -124,7 +124,7 @@ receive_message(Message) ->
 
 %% @doc Attempt to join a remote node.
 join(Node) ->
-    join(Node).
+    gen_server:call(?MODULE, {join, Node}, infinity).
 
 %% @doc Leave the cluster.
 leave() ->

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -317,7 +317,7 @@ handle_info({'EXIT', From, _Reason}, #state{connections=Connections0}=State) ->
     %% invoke the down callback on each matching entry
     partisan_peer_service_connections:foreach(
           fun(Node, Pids) ->
-                case lists:member(From, Pids) of
+                case lists:keymember(From, 2, Pids) of
                     true ->
                         down(Node, State);
                     false ->
@@ -588,9 +588,8 @@ do_send_message(Node, Message, Connections) ->
         {ok, []} ->
             %% Node was connected but is now disconnected.
             {error, disconnected};
-        {ok, [Pid|_]} ->
-            %% TODO: Eventually be smarter about the process identifier
-            %% selection.
+        {ok, Entries} ->
+            {_ListenAddr, Pid} = lists:nth(rand_compat:uniform(length(Entries)), Entries),
             gen_server:cast(Pid, {send_message, Message});
         {error, not_found} ->
             %% Node has not been connected yet.

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -633,14 +633,6 @@ internal_leave(Node, #state{actor=Actor,
     State#state{membership=Membership}.
 
 %% @private
-internal_join(Node, State) when is_atom(Node) ->
-    ListenAddrs = rpc:call(Node, partisan_config, listen_addrs, []),
-
-    FoldFun = fun({_Label, PeerIP, PeerPort}, State0) ->
-                    internal_join(#{name => Node, ip => PeerIP, port => PeerPort},
-                                   State0)
-              end,
-    lists:foldl(FoldFun, State, ListenAddrs);
 internal_join(#{name := Name} = Node,
               #state{pending=Pending0,
                      connections=Connections0,

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -268,7 +268,7 @@ handle_call(partitions, _From, #state{partitions=Partitions}=State) ->
 handle_call({leave, _Node}, _From, State) ->
     {reply, error, State};
 
-handle_call({join, {_Name, _, _}=Node}, _From, State) ->
+handle_call({join, #{name := _Name} = Node}, _From, State) ->
     gen_server:cast(?MODULE, {join, Node}),
     {reply, ok, State};
 
@@ -304,6 +304,7 @@ handle_call({reserve, Tag}, _From,
             #state{reserved=Reserved0,
                    max_active_size=MaxActiveSize}=State) ->
     Present = dict:fetch_keys(Reserved0),
+
     case length(Present) < MaxActiveSize of
         true ->
             Reserved = case lists:member(Tag, Present) of
@@ -324,7 +325,7 @@ handle_call({active, Tag},
             _From,
             #state{reserved=Reserved}=State) ->
     Result = case dict:find(Tag, Reserved) of
-        {ok, {Peer, _, _}} ->
+        {ok, #{name := Peer}} ->
             {ok, Peer};
         {ok, undefined} ->
             {ok, undefined};
@@ -344,7 +345,15 @@ handle_call({send_message, Name, Message}, _From,
 
 handle_call({forward_message, Name, ServerRef, Message}, _From,
             #state{connections=Connections0, partitions=Partitions}=State) ->
-    case lists:keymember(Name, 2, Partitions) of
+    IsPartitioned = lists:any(fun(#{name := N}) ->
+                                      case N of
+                                          Name ->
+                                              true;
+                                          _ ->
+                                              false
+                                      end
+                              end, Partitions),
+    case IsPartitioned of
         true ->
             {reply, {error, partitioned}, State};
         false ->
@@ -361,7 +370,7 @@ handle_call({receive_message, Message}, _From, State) ->
 handle_call(members, _From, #state{myself=Myself,
                                    active=Active}=State) ->
     lager:info("Node ~p active view: ~p", [Myself, members(Active)]),
-    ActiveMembers = [P || {P, _, _} <- members(Active)],
+    ActiveMembers = [P || #{name := P} <- members(Active)],
     {reply, {ok, ActiveMembers}, State};
 
 handle_call(get_local_state, _From, #state{active=Active,
@@ -1125,7 +1134,7 @@ select_random_sublist(View, K) ->
 %% network delay; if so, we have to remove this element from the passive
 %% view, otherwise it will exist in both places.
 %%
-add_to_active_view({Name, _, _}=Peer, Tag,
+add_to_active_view(#{name := Name}=Peer, Tag,
                    #state{active=Active0,
                           myself=Myself,
                           passive=Passive0,
@@ -1177,7 +1186,7 @@ add_to_active_view({Name, _, _}=Peer, Tag,
     end.
 
 %% @doc Add to the passive view.
-add_to_passive_view({Name, _, _}=Peer,
+add_to_passive_view(#{name := Name}=Peer,
                     #state{myself=Myself,
                            active=Active0,
                            passive=Passive0,

--- a/src/partisan_peer_service.erl
+++ b/src/partisan_peer_service.erl
@@ -52,7 +52,7 @@ join(NodeStr, Auto) when is_list(NodeStr) ->
     join(erlang:list_to_atom(lists:flatten(NodeStr)), Auto);
 join(Node, Auto) when is_atom(Node) ->
     join(node(), Node, Auto);
-join({_Name, _IPAddress, _Port} = Node, _Auto) ->
+join(Node, _Auto) ->
     attempt_join(Node).
 
 %% @doc Initiate join. Nodes cannot join themselves.
@@ -88,7 +88,7 @@ forward_message(Name, ServerRef, Message) ->
 %% @private
 decode(State) ->
     Manager = manager(),
-    [P || {P, _, _} <- Manager:decode(State)].
+    [P || #{name := P} <- Manager:decode(State)].
 
 %% @private
 attempt_join(Node) when is_atom(Node) ->
@@ -102,8 +102,8 @@ attempt_join(Node) when is_atom(Node) ->
                         partisan_config,
                         get,
                         [peer_port]),
-    attempt_join({Node, PeerIP, PeerPort});
-attempt_join({_Name, _, _}=Node) ->
+    attempt_join(#{name => Node, ip => PeerIP, port => PeerPort});
+attempt_join(#{name := _Name} = Node) ->
     Manager = manager(),
     Manager:join(Node).
 

--- a/src/partisan_peer_service.erl
+++ b/src/partisan_peer_service.erl
@@ -92,17 +92,8 @@ decode(State) ->
 
 %% @private
 attempt_join(Node) when is_atom(Node) ->
-    %% Use RPC to get the node's specific IP and port binding
-    %% information for the partisan backend connections.
-    PeerIP = rpc:call(Node,
-                      partisan_config,
-                      get,
-                      [peer_ip]),
-    PeerPort = rpc:call(Node,
-                        partisan_config,
-                        get,
-                        [peer_port]),
-    attempt_join(#{name => Node, ip => PeerIP, port => PeerPort});
+    ListenAddrs = rpc:call(Node, partisan_config, get, [listen_addrs]),
+    attempt_join(#{name => Node, listen_addrs => ListenAddrs});
 attempt_join(#{name := _Name} = Node) ->
     Manager = manager(),
     Manager:join(Node).

--- a/src/partisan_peer_service_connections.erl
+++ b/src/partisan_peer_service_connections.erl
@@ -111,10 +111,10 @@ find_first_name(Name, [_|Rest]) -> find_first_name(Name, Rest).
 -include_lib("eunit/include/eunit.hrl").
 
 node1() ->
-    #{name => node1, ip => {127, 0, 0, 1}, port => 80}.
+    #{name => node1, listen_addrs => [#{ip => {127, 0, 0, 1}, port => 80}]}.
 
 node2() ->
-    #{name => node2, ip => {127, 0, 0, 1}, port => 81}.
+    #{name => node2, listen_addrs => [#{ip => {127, 0, 0, 1}, port => 81}]}.
 
 no_connections_test() ->
     Connections0 = new(),
@@ -139,26 +139,32 @@ prune_connections_test() ->
     Connections1 = store(node1(), self(), Connections0),
     Connections2 = store(node1(), self(), Connections1),
     ?assertEqual({ok, [self(), self()]}, find(node1(), Connections2)),
-    {#{name := node1, ip := {127, 0, 0, 1}, port := 80}, Connections3} = prune(self(), Connections2),
+    {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
+     Connections3} = prune(self(), Connections2),
     ?assertEqual({ok, [self()]}, find(node1(), Connections3)),
-    {#{name := node1, ip := {127, 0, 0, 1}, port := 80}, Connections4} = prune(self(), Connections3),
+    {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
+     Connections4} = prune(self(), Connections3),
     ?assertEqual({ok, []}, find(node1(), Connections4)),
     Connections5 = store(node1(), self(), Connections4),
     Connections6 = store(node1(), self(), Connections5),
-    {#{name := node1, ip := {127, 0, 0, 1}, port := 80}, Connections7} = prune(self(), Connections6),
+    {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
+     Connections7} = prune(self(), Connections6),
     ?assertEqual({ok, [self()]}, find(node1, Connections7)),
-    {#{name := node1, ip := {127, 0, 0, 1}, port := 80}, Connections8} = prune(self(), Connections7),
+    {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
+     Connections8} = prune(self(), Connections7),
     ?assertEqual({ok, []}, find(node1, Connections8)).
 
 add_remove_add_connection_test() ->
     Connections0 = new(),
     Connections1 = store(node1(), self(), Connections0),
     ?assertEqual({ok, [self()]}, find(node1, Connections1)),
-    {#{name := node1, ip := {127, 0, 0, 1}, port := 80}, Connections2} = prune(self(), Connections1),
+    {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
+     Connections2} = prune(self(), Connections1),
     ?assertEqual({ok, []}, find(node1, Connections2)),
     Connections3 = store(node1(), self(), Connections2),
     ?assertEqual({ok, [self()]}, find(node1, Connections3)),
-    {#{name := node1, ip := {127, 0, 0, 1}, port := 80}, Connections4} = prune(node1(), Connections3),
+    {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
+     Connections4} = prune(node1(), Connections3),
     ?assertEqual({ok, []}, find(node1, Connections4)).
 
 -endif.

--- a/src/partisan_peer_service_connections.erl
+++ b/src/partisan_peer_service_connections.erl
@@ -32,6 +32,9 @@
 -type t() :: dict:dict(node_spec(), list(pid())).
 -export_type([t/0]).
 
+-type entries() :: [entry()].
+-type entry() :: {listen_addr(), pid()}.
+
 %% @doc Creates a new dictionary of connections.
 -spec new() -> t().
 new() ->
@@ -39,35 +42,30 @@ new() ->
 
 %% @doc Finds connection pids in dictionary either by name or node spec.
 -spec find(Node :: atom() | node_spec(),
-           Connections :: t()) -> {ok, list(pid())} | {error, not_found}.
+           Connections :: t()) -> {ok, entries()} | {error, not_found}.
 find(Name, Connections) when is_atom(Name) ->
     find_first_name(Name, dict:to_list(Connections));
 find(Node, Connections) ->
     case dict:find(Node, Connections) of
         error ->
             {error, not_found};
-        {ok, Pids} ->
-            {ok, Pids}
+        {ok, Entries} ->
+            {ok, Entries}
     end.
 
 %% @doc Store a connection pid
 -spec store(Node :: node_spec(),
-            Pid :: undefined | pid(),
+            Entry :: entry(),
             Connections :: t()) -> t().
-store(Node, Pid0, Connections) ->
-    Pid = case Pid0 of
-            undefined ->
-                  [];
-            _ ->
-                  [Pid0]
-          end,
+store(Node, {_ListenAddr, _Pids} = Entry, Connections) ->
     case find(Node, Connections) of
         {error, not_found} ->
-            dict:store(Node, Pid, Connections);
+            dict:store(Node, [Entry], Connections);
         _ ->
-            dict:fold(fun(Node0, Pids, ConnectionsIn) when Node0 =:= Node ->
-                            dict:store(Node, Pids ++ Pid, ConnectionsIn);
-                         (_Node, _Pids, ConnectionsIn) -> ConnectionsIn
+            dict:fold(fun(Node0, Entries, ConnectionsIn) when Node0 =:= Node ->
+                              dict:store(Node, Entries ++ [Entry], ConnectionsIn);
+                         (_Node, _Entries, ConnectionsIn) ->
+                              ConnectionsIn
                       end, Connections, Connections)
     end.
 
@@ -77,12 +75,12 @@ store(Node, Pid0, Connections) ->
             Connections :: t()) -> {node_spec(), t()}.
 prune(#{name := _Name} = Node, Connections) ->
     {Node, dict:store(Node, [], Connections)};
-prune(Pid, Connections) ->
-    dict:fold(fun(Node, Pids, {AccNode, ConnectionsIn}) ->
-                    case lists:member(Pid, Pids) of
+prune(Pid, Connections) when is_pid(Pid) ->
+    dict:fold(fun(Node, Entries, {AccNode, ConnectionsIn}) ->
+                    case lists:keymember(Pid, 2, Entries) of
                         true ->
                             {Node,
-                             dict:store(Node, lists:subtract(Pids, [Pid]), ConnectionsIn)};
+                             dict:store(Node, lists:keydelete(Pid, 2, Entries), ConnectionsIn)};
                         false ->
                             {AccNode, ConnectionsIn}
                     end
@@ -97,10 +95,10 @@ foreach(Fun, Connections) ->
 
 %% @private
 -spec find_first_name(Name :: atom(),
-                      ConnectionsList :: [{node_spec(), list(pid())}]) ->
-            {ok, list(pid())} | {error, not_found}.
+                      ConnectionsList :: [{node_spec(), entries()}]) ->
+            {ok, entries()} | {error, not_found}.
 find_first_name(_Name, []) -> {error, not_found};
-find_first_name(Name, [{#{name := Name}, Pids}|_]) -> {ok, Pids};
+find_first_name(Name, [{#{name := Name}, Entries}|_]) -> {ok, Entries};
 find_first_name(Name, [_|Rest]) -> find_first_name(Name, Rest).
 
 %%
@@ -111,10 +109,22 @@ find_first_name(Name, [_|Rest]) -> find_first_name(Name, Rest).
 -include_lib("eunit/include/eunit.hrl").
 
 node1() ->
-    #{name => node1, listen_addrs => [#{ip => {127, 0, 0, 1}, port => 80}]}.
+    #{name => node1, listen_addrs => [node1_listen_addr()]}.
+
+node1_listen_addr() ->
+    #{ip => {127, 0, 0, 1}, port => 80}.
 
 node2() ->
-    #{name => node2, listen_addrs => [#{ip => {127, 0, 0, 1}, port => 81}]}.
+    #{name => node2, listen_addrs => [node2_listen_addr()]}.
+
+node2_listen_addr() ->
+    #{ip => {127, 0, 0, 1}, port => 81}.
+
+node1_bind() ->
+    {node1_listen_addr(), self()}.
+
+node2_bind() ->
+    {node2_listen_addr(), self()}.
 
 no_connections_test() ->
     Connections0 = new(),
@@ -122,47 +132,47 @@ no_connections_test() ->
 
 one_connection_test() ->
     Connections0 = new(),
-    Connections1 = store(node1(), self(), Connections0),
-    ?assertEqual({ok, [self()]}, find(node1(), Connections1)),
-    Connections2 = store(node2(), self(), Connections1),
-    ?assertEqual({ok, [self()]}, find(node2, Connections2)).
+    Connections1 = store(node1(), node1_bind(), Connections0),
+    ?assertEqual({ok, [node1_bind()]}, find(node1(), Connections1)),
+    Connections2 = store(node2(), node2_bind(), Connections1),
+    ?assertEqual({ok, [node2_bind()]}, find(node2, Connections2)).
 
 several_connections_test() ->
     Connections0 = new(),
-    Connections1 = store(node1(), self(), Connections0),
-    Connections2 = store(node1(), self(), Connections1),
-    ?assertEqual({ok, [self(), self()]}, find(node1(), Connections2)),
-    ?assertEqual({ok, [self(), self()]}, find(node1, Connections2)).
+    Connections1 = store(node1(), node1_bind(), Connections0),
+    Connections2 = store(node1(), node1_bind(), Connections1),
+    ?assertEqual({ok, [node1_bind(), node1_bind()]}, find(node1(), Connections2)),
+    ?assertEqual({ok, [node1_bind(), node1_bind()]}, find(node1, Connections2)).
 
 prune_connections_test() ->
     Connections0 = new(),
-    Connections1 = store(node1(), self(), Connections0),
-    Connections2 = store(node1(), self(), Connections1),
-    ?assertEqual({ok, [self(), self()]}, find(node1(), Connections2)),
+    Connections1 = store(node1(), node1_bind(), Connections0),
+    Connections2 = store(node1(), node1_bind(), Connections1),
+    ?assertEqual({ok, [node1_bind(), node1_bind()]}, find(node1(), Connections2)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections3} = prune(self(), Connections2),
-    ?assertEqual({ok, [self()]}, find(node1(), Connections3)),
+    ?assertEqual({ok, [node1_bind()]}, find(node1(), Connections3)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections4} = prune(self(), Connections3),
     ?assertEqual({ok, []}, find(node1(), Connections4)),
-    Connections5 = store(node1(), self(), Connections4),
-    Connections6 = store(node1(), self(), Connections5),
+    Connections5 = store(node1(), node1_bind(), Connections4),
+    Connections6 = store(node1(), node1_bind(), Connections5),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections7} = prune(self(), Connections6),
-    ?assertEqual({ok, [self()]}, find(node1, Connections7)),
+    ?assertEqual({ok, [node1_bind()]}, find(node1, Connections7)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections8} = prune(self(), Connections7),
     ?assertEqual({ok, []}, find(node1, Connections8)).
 
 add_remove_add_connection_test() ->
     Connections0 = new(),
-    Connections1 = store(node1(), self(), Connections0),
-    ?assertEqual({ok, [self()]}, find(node1, Connections1)),
+    Connections1 = store(node1(), node1_bind(), Connections0),
+    ?assertEqual({ok, [node1_bind()]}, find(node1, Connections1)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections2} = prune(self(), Connections1),
     ?assertEqual({ok, []}, find(node1, Connections2)),
-    Connections3 = store(node1(), self(), Connections2),
-    ?assertEqual({ok, [self()]}, find(node1, Connections3)),
+    Connections3 = store(node1(), node1_bind(), Connections2),
+    ?assertEqual({ok, [node1_bind()]}, find(node1, Connections3)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections4} = prune(node1(), Connections3),
     ?assertEqual({ok, []}, find(node1, Connections4)).

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -52,7 +52,8 @@
 -callback resolve_partition(reference()) -> ok | {error, not_implemented}.
 
 -spec myself() -> node_spec().
+
 myself() ->
     Port = partisan_config:get(peer_port, ?PEER_PORT),
     IPAddress = partisan_config:get(peer_ip, ?PEER_IP),
-    {node(), IPAddress, Port}.
+    #{name => node(), ip => IPAddress, port => Port}.

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -56,4 +56,5 @@
 myself() ->
     Port = partisan_config:get(peer_port, ?PEER_PORT),
     IPAddress = partisan_config:get(peer_ip, ?PEER_IP),
-    #{name => node(), ip => IPAddress, port => Port}.
+    Parallelism = partisan_config:get(parallelism, ?PEER_IP),
+    #{name => node(), ip => IPAddress, port => Port, parallelism => Parallelism}.

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -54,7 +54,6 @@
 -spec myself() -> node_spec().
 
 myself() ->
-    Port = partisan_config:get(peer_port, ?PEER_PORT),
-    IPAddress = partisan_config:get(peer_ip, ?PEER_IP),
-    Parallelism = partisan_config:get(parallelism, ?PEER_IP),
-    #{name => node(), ip => IPAddress, port => Port, parallelism => Parallelism}.
+    Parallelism = partisan_config:get(parallelism, ?PARALLELISM),
+    ListenAddrs = partisan_config:get(listen_addrs, ?LISTEN_ADDRS),
+    #{name => node(), listen_addrs => ListenAddrs, parallelism => Parallelism}.

--- a/src/partisan_pool.erl
+++ b/src/partisan_pool.erl
@@ -1,4 +1,25 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(partisan_pool).
+-author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
 
 -behaviour(acceptor_pool).
 

--- a/src/partisan_pool_sup.erl
+++ b/src/partisan_pool_sup.erl
@@ -20,14 +20,13 @@ start_link() ->
 init([]) ->
     Flags = #{strategy => rest_for_one},
     Pool = pool(),
-    Sockets = [socket(PeerIP, PeerPort) || {PeerIP, PeerPort} <-
-                                           partisan_config:listen_addrs()],
+    Sockets = [socket(ListenAddr) || ListenAddr <- partisan_config:listen_addrs()],
     {ok, {Flags, lists:flatten([Pool, Sockets])}}.
 
 %% @private
-socket(PeerIP, PeerPort) ->
+socket({Label, PeerIP, PeerPort}) ->
     #{id => partisan_socket,
-      start => {partisan_socket, start_link, [PeerIP, PeerPort]}}.
+      start => {partisan_socket, start_link, [Label, PeerIP, PeerPort]}}.
 
 %% @private
 pool() ->

--- a/src/partisan_pool_sup.erl
+++ b/src/partisan_pool_sup.erl
@@ -1,4 +1,25 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(partisan_pool_sup).
+-author("Christopher Meiklejohn <christopher.meiklejohn@gmail.com>").
 
 -behaviour(supervisor).
 

--- a/src/partisan_pool_sup.erl
+++ b/src/partisan_pool_sup.erl
@@ -45,9 +45,8 @@ init([]) ->
     {ok, {Flags, lists:flatten([Pool, Sockets])}}.
 
 %% @private
-socket({Label, PeerIP, PeerPort}) ->
-    #{id => partisan_socket,
-      start => {partisan_socket, start_link, [Label, PeerIP, PeerPort]}}.
+socket(#{ip := IP, port := Port}) ->
+    #{id => partisan_socket, start => {partisan_socket, start_link, [IP, Port]}}.
 
 %% @private
 pool() ->

--- a/src/partisan_socket.erl
+++ b/src/partisan_socket.erl
@@ -77,6 +77,8 @@ terminate(_, {_Label, Socket, MRef}) ->
     % Socket may already be down but need to ensure it is closed to avoid
     % eaddrinuse error on restart
     case demonitor(MRef, [flush, info]) of
-        true  -> gen_tcp:close(Socket);
-        false -> ok
+        true  ->
+            gen_tcp:close(Socket);
+        false ->
+            ok
     end.

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -266,7 +266,7 @@ terminate(_Reason, #state{connections=Connections}=_State) ->
     Fun =
         fun(_K, Pids) ->
             lists:foreach(
-              fun(Pid) ->
+              fun({_ListenAddr, Pid}) ->
                  try
                      gen_server:stop(Pid, normal, infinity)
                  catch
@@ -366,7 +366,8 @@ do_send_message(Node, Message, Connections) ->
         {ok, []} ->
             %% Node was connected but is now disconnected.
             {error, disconnected};
-        {ok, [Pid|_]} ->
+        {ok, Entries} ->
+            {_ListenAddr, Pid} = lists:nth(rand_compat:uniform(length(Entries)), Entries),
             gen_server:cast(Pid, {send_message, Message});
         {error, not_found} ->
             %% Node has not been connected yet.

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -24,8 +24,7 @@
 -include("partisan.hrl").
 
 -export([build_tree/3,
-         maybe_connect/2,
-         maybe_connect/3]).
+         maybe_connect/2]).
 
 %% @doc Convert a list of elements into an N-ary tree. This conversion
 %%      works by treating the list as an array-based tree where, for
@@ -62,24 +61,8 @@ build_tree(N, Nodes, Opts) ->
 -spec maybe_connect(Node :: node_spec(),
                     Connections :: partisan_peer_service_connections:t()) ->
             partisan_peer_service_connections:t().
-maybe_connect(Node, Connections0) ->
-    maybe_connect(Node, Connections0, dict:new()).
-
--spec maybe_connect(Node :: node_spec(),
-                    Connections :: partisan_peer_service_connections:t(),
-                    MemberParallelism :: dict:dict()) ->
-            partisan_peer_service_connections:t().
-maybe_connect(#{name := Name} = Node, Connections0, MemberParallelism) ->
-    %% Compute desired parallelism.
-    Parallelism  = case dict:find(Name, MemberParallelism) of
-        {ok, V} ->
-            %% We learned about a node via an explicit join.
-            V;
-        error ->
-            %% We learned about a node through a state merge; assume the
-            %% default unless later specified.
-            partisan_config:get(parallelism, ?PARALLELISM)
-    end,
+maybe_connect(#{name := _Name} = Node, Connections0) ->
+    Parallelism = maps:get(parallelism, Node, ?PARALLELISM),
 
     %% Initiate connections.
     Connections = case partisan_peer_service_connections:find(Node, Connections0) of

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -79,10 +79,10 @@ maybe_connect_listen_addr(Node, ListenAddr, Connections0) ->
             case connect(Node, ListenAddr) of
                 {ok, Pid} ->
                     lager:info("Node ~p connected.", [Node]),
-                    partisan_peer_service_connections:store(Node, Pid, Connections0);
+                    partisan_peer_service_connections:store(Node, {ListenAddr, Pid}, Connections0);
                 Error ->
                     lager:info("Node ~p failed connection: ~p.", [Node, Error]),
-                    partisan_peer_service_connections:store(Node, undefined, Connections0)
+                    Connections0
             end;
         %% Found and connected.
         {ok, Pids} ->

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -69,9 +69,9 @@ maybe_connect(Node, Connections0) ->
                     Connections :: partisan_peer_service_connections:t(),
                     MemberParallelism :: dict:dict()) ->
             partisan_peer_service_connections:t().
-maybe_connect(Node, Connections0, MemberParallelism) ->
+maybe_connect(#{name := Name} = Node, Connections0, MemberParallelism) ->
     %% Compute desired parallelism.
-    Parallelism  = case dict:find(Node, MemberParallelism) of
+    Parallelism  = case dict:find(Name, MemberParallelism) of
         {ok, V} ->
             %% We learned about a node via an explicit join.
             V;
@@ -137,4 +137,3 @@ maybe_connect(Node, Connections0, MemberParallelism) ->
 connect(Node) ->
     Self = self(),
     partisan_peer_service_client:start_link(Node, Self).
-

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -639,7 +639,7 @@ start(_Case, Config, Options) ->
             Parallelism = case ?config(parallelism, Config) of
                               undefined ->
                                   1;
-                                Other ->
+                              Other ->
                                   Other
                           end,
             ct:pal("Setting parallelism to: ~p", [Parallelism]),

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -636,8 +636,14 @@ start(_Case, Config, Options) ->
                           [max_active_size, MaxActiveSize]),
 
             ok = rpc:call(Node, partisan_config, set, [tls, ?config(tls, Config)]),
-            ct:pal("Setting parallelism to: ~p", [?config(parallelism, Config)]),
-            ok = rpc:call(Node, partisan_config, set, [parallelism, ?config(parallelism, Config)]),
+            Parallelism = case ?config(parallelism, Config) of
+                              undefined ->
+                                  1;
+                                Other ->
+                                  Other
+                          end,
+            ct:pal("Setting parallelism to: ~p", [Parallelism]),
+            ok = rpc:call(Node, partisan_config, set, [parallelism, Parallelism]),
 
             Servers = proplists:get_value(servers, Options, []),
             Clients = proplists:get_value(clients, Options, []),

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -145,6 +145,8 @@ default_manager_test(Config) ->
                 true ->
                     true;
                 false ->
+                    ct:pal("Membership incorrect; node ~p should have ~p but has ~p",
+                           [Node, SortedNodes, SortedMembers]),
                     {false, {Node, SortedNodes, SortedMembers}}
             end
     end,
@@ -777,8 +779,7 @@ cluster({_, Node}, {_, OtherNode}, Config) ->
                   partisan_peer_service,
                   join,
                   [#{name => OtherNode,
-                     ip => {127, 0, 0, 1},
-                     port => PeerPort,
+                     listen_addrs => [#{ip => {127, 0, 0, 1}, port => PeerPort}],
                      parallelism => Parallelism}]).
 
 %% @private


### PR DESCRIPTION
- [x] Replace the use of the 3-tuple with a map to allow us to easily alter the structure later in all peer service managers.
- [x] Deprecate peer_ip and peer_port in favor of listen addresses.
- [x] Remove member parallelism and replace with field in the map.
- [x] Alter structure of connection dictionary to be node-to-map-of-listen-addresses-to-number-of-connections.