### PR TITLE
remove use of IP and PEER_PORT os vars

### DIFF
--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -1,7 +1,6 @@
 -define(APP, partisan).
 -define(PEER_IP, {127, 0, 0, 1}).
 -define(PEER_PORT, 9000).
--define(LISTEN_ADDRS, [#{ip => ?PEER_IP, port => ?PEER_PORT}]).
 -define(PEER_SERVICE_SERVER, partisan_peer_service_server).
 -define(FANOUT, 5).
 -define(CACHE, partisan_connection_cache).

--- a/src/partisan.app.src
+++ b/src/partisan.app.src
@@ -1,6 +1,6 @@
 {application,partisan,
              [{description,"Scalable peer service for Lasp"},
-              {vsn,"1.0.0"},
+              {vsn,"1.0.2"},
               {registered,[]},
               {applications,[kernel,stdlib,crypto,lager,types,time_compat,
                              rand_compat,acceptor_pool,ssl]},

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -55,5 +55,5 @@
 
 myself() ->
     Parallelism = partisan_config:get(parallelism, ?PARALLELISM),
-    ListenAddrs = partisan_config:get(listen_addrs, ?LISTEN_ADDRS),
+    ListenAddrs = partisan_config:get(listen_addrs),
     #{name => node(), listen_addrs => ListenAddrs, parallelism => Parallelism}.


### PR DESCRIPTION
Also removes unneeded (since `listen_addrs` will get set on startup) uses of `?LISTEN_ADDRS` that are confusing since they won't be used but that isn't obvious without investigating the code further.