### PR TITLE
Use the resolution of node name.

### DIFF
--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -104,7 +104,7 @@ random_port() ->
 %% @private
 get_node_address() ->
     Name = atom_to_list(node()),
-    [_Name, FQDN] = string:split(Name, "@", all),
+    [_Name, FQDN] = string:tokens(Name, "@"),
     case inet:getaddr(FQDN, inet) of
         {ok, Address} ->
             Address;

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -104,13 +104,13 @@ random_port() ->
 %% @private
 get_node_address() ->
     Name = atom_to_list(node()),
-    [_Name, FQDN] = string:tokens(Name, "@"),
+    [_Hostname, FQDN] = string:tokens(Name, "@"),
+    lager:info("Resolving ~p...", [FQDN]),
     case inet:getaddr(FQDN, inet) of
         {ok, Address} ->
             lager:info("Resolved ~p to ~p", [Name, Address]),
-            exit(Address),
-            ?PEER_IP;
+            Address;
         {error, Error} ->
-            lager:info("Cannot resolve local name ~p, resulting to 127.0.0.1: ~p", [FQDN, Error]),
+            lager:error("Cannot resolve local name ~p, resulting to 127.0.0.1: ~p", [FQDN, Error]),
             ?PEER_IP
     end.

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -107,7 +107,8 @@ get_node_address() ->
     [_Name, FQDN] = string:tokens(Name, "@"),
     case inet:getaddr(FQDN, inet) of
         {ok, Address} ->
-            Address;
+            lager:info("Resolved ~p to ~p", [Name, Address]),
+            ?PEER_IP;
         {error, Error} ->
             lager:info("Cannot resolve local name ~p, resulting to 127.0.0.1: ~p", [FQDN, Error]),
             ?PEER_IP

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -60,7 +60,7 @@ init() ->
                            {max_passive_size, 30},
                            {min_active_size, 3},
                            {partisan_peer_service_manager, PeerService},
-                           {peer_ip, get_node_address()},
+                           {peer_ip, try_get_node_address()},
                            {peer_port, random_port()},
                            {random_promotion, true},
                            {reservations, []},
@@ -100,6 +100,15 @@ random_port() ->
     {ok, {_, Port}} = inet:sockname(Socket),
     ok = gen_tcp:close(Socket),
     Port.
+
+%% @private
+try_get_node_address() ->
+    case application:get_env(partisan, peer_ip) of
+        {ok, Address} ->
+            Address;
+        undefined ->
+            get_node_address()
+    end.
 
 %% @private
 get_node_address() ->

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -108,6 +108,7 @@ get_node_address() ->
     case inet:getaddr(FQDN, inet) of
         {ok, Address} ->
             lager:info("Resolved ~p to ~p", [Name, Address]),
+            exit(Address),
             ?PEER_IP;
         {error, Error} ->
             lager:info("Cannot resolve local name ~p, resulting to 127.0.0.1: ~p", [FQDN, Error]),

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -634,7 +634,7 @@ start(_Case, Config, Options) ->
     ct:pal("Launching Erlang distribution..."),
 
     os:cmd(os:find_executable("epmd") ++ " -daemon"),
-    {ok, Hostname} = inet:gethostname(),
+    Hostname = "localhost",
     case net_kernel:start([list_to_atom("runner@" ++ Hostname), shortnames]) of
         {ok, _} ->
             ok;

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -884,7 +884,8 @@ connect(G, N1, N2) ->
     ok.
 
 %% @private
-node_list(0, _Name, _Config) -> [];
+node_list(0, _Name, _Config) -> 
+    [];
 node_list(N, Name, Config) ->
     [ list_to_atom(string:join([Name,
                                 integer_to_list(?config(hash, Config)),
@@ -898,7 +899,8 @@ make_certs(Config) ->
     PrivDir = ?config(priv_dir, Config),
     ct:pal("Generating TLS certificates into ~s", [PrivDir]),
     MakeCertsFile = filename:join(DataDir, "make_certs.erl"),
-    {ok, make_certs, ModBin} = compile:file(MakeCertsFile, [binary, debug_info, report_errors, report_warnings]),
+    {ok, make_certs, ModBin} = compile:file(MakeCertsFile, 
+        [binary, debug_info, report_errors, report_warnings]),
     {module, make_certs} = code:load_binary(make_certs, MakeCertsFile, ModBin),
 
     make_certs:all(DataDir, PrivDir),

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -633,8 +633,8 @@ start(_Case, Config, Options) ->
     %% Launch distribution for the test runner.
     ct:pal("Launching Erlang distribution..."),
 
+    {ok, Hostname} = inet:gethostname(), 
     os:cmd(os:find_executable("epmd") ++ " -daemon"),
-    Hostname = "localhost",
     case net_kernel:start([list_to_atom("runner@" ++ Hostname), shortnames]) of
         {ok, _} ->
             ok;


### PR DESCRIPTION
Resolve the node name and use the node name for the default IP address, instead of 127.0.0.1.