### PR TITLE
Provide cast/forward behavior.

### DIFF
--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -103,7 +103,8 @@ send_message(Name, Message) ->
 %% @doc Cast a message to a remote gen_server.
 cast_message(Name, ServerRef, Message) ->
     FullMessage = {'$gen_cast', Message},
-    forward_message(Name, ServerRef, FullMessage).
+    forward_message(Name, ServerRef, FullMessage),
+    ok.
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -412,7 +412,7 @@ establish_connections(Pending, Membership, Connections) ->
     lists:foldl(fun partisan_util:maybe_connect/2, Connections, AllPeers).
 
 handle_message({forward_message, ServerRef, Message}, State) ->
-    gen_server:cast(ServerRef, Message),
+    ServerRef ! Message,
     {reply, ok, State}.
 
 %% @private

--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -36,6 +36,7 @@
          on_down/2,
          update_members/1,
          send_message/2,
+         cast_message/3,
          forward_message/3,
          receive_message/1,
          decode/1,
@@ -98,6 +99,11 @@ update_members(_Nodes) ->
 %% @doc Send message to a remote manager.
 send_message(Name, Message) ->
     gen_server:call(?MODULE, {send_message, Name, Message}, infinity).
+
+%% @doc Cast a message to a remote gen_server.
+cast_message(Name, ServerRef, Message) ->
+    FullMessage = {'$gen_cast', Message},
+    forward_message(Name, ServerRef, FullMessage).
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -110,7 +110,8 @@ send_message(Name, Message) ->
 %% @doc Cast a message to a remote gen_server.
 cast_message(Name, ServerRef, Message) ->
     FullMessage = {'$gen_cast', Message},
-    forward_message(Name, ServerRef, FullMessage).
+    forward_message(Name, ServerRef, FullMessage),
+    ok.
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -35,6 +35,7 @@
          update_members/1,
          on_down/2,
          send_message/2,
+         cast_message/3,
          forward_message/3,
          receive_message/1,
          decode/1,
@@ -105,6 +106,11 @@ on_down(Name, Function) ->
 %% @doc Send message to a remote manager.
 send_message(Name, Message) ->
     gen_server:call(?MODULE, {send_message, Name, Message}, infinity).
+
+%% @doc Cast a message to a remote gen_server.
+cast_message(Name, ServerRef, Message) ->
+    FullMessage = {'$gen_cast', Message},
+    forward_message(Name, ServerRef, FullMessage).
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->
@@ -535,7 +541,7 @@ handle_message({receive_state, PeerMembership},
             end
     end;
 handle_message({forward_message, ServerRef, Message}, State) ->
-    gen_server:cast(ServerRef, Message),
+    ServerRef ! Message,
     {reply, ok, State}.
 
 %% @private

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -129,7 +129,8 @@ send_message(Name, Message) ->
 %% @doc Cast a message to a remote gen_server.
 cast_message(Name, ServerRef, Message) ->
     FullMessage = {'$gen_cast', Message},
-    forward_message(Name, ServerRef, FullMessage).
+    forward_message(Name, ServerRef, FullMessage),
+    ok.
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -40,6 +40,7 @@
          update_members/1,
          on_down/2,
          send_message/2,
+         cast_message/3,
          forward_message/3,
          receive_message/1,
          decode/1,
@@ -124,6 +125,11 @@ update_members(_Nodes) ->
 %% @doc Send message to a remote manager.
 send_message(Name, Message) ->
     gen_server:call(?MODULE, {send_message, Name, Message}, infinity).
+
+%% @doc Cast a message to a remote gen_server.
+cast_message(Name, ServerRef, Message) ->
+    FullMessage = {'$gen_cast', Message},
+    forward_message(Name, ServerRef, FullMessage).
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -1015,7 +1015,7 @@ handle_message({shuffle, Exchange, TTL, Sender},
     {noreply, State};
 
 handle_message({forward_message, ServerRef, Message}, State) ->
-    gen_server:cast(ServerRef, Message),
+    ServerRef ! Message,
     {noreply, State}.
 
 %% @private

--- a/src/partisan_peer_service.erl
+++ b/src/partisan_peer_service.erl
@@ -34,6 +34,7 @@
          connections/0,
          manager/0,
          add_sup_callback/1,
+         cast_message/3,
          forward_message/3]).
 
 -include("partisan.hrl").
@@ -79,6 +80,11 @@ update_members(Nodes) ->
 %% @doc Add callback.
 add_sup_callback(Function) ->
     partisan_peer_service_events:add_sup_callback(Function).
+
+%% @doc Cast message to registered process on the remote side.
+cast_message(Name, ServerRef, Message) ->
+    Manager = manager(),
+    Manager:cast_message(Name, ServerRef, Message).
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -39,6 +39,7 @@
 
 -callback send_message(name(), message()) -> ok.
 -callback receive_message(message()) -> ok.
+-callback cast_message(name(), pid(), message()) -> ok.
 -callback forward_message(name(), pid(), message()) -> ok.
 
 -callback on_down(name(), function()) -> ok | {error, not_implemented}.

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -359,7 +359,7 @@ establish_connections(Pending, Membership, Connections) ->
     lists:foldl(fun partisan_util:maybe_connect/2, Connections, AllPeers).
 
 handle_message({forward_message, ServerRef, Message}, State) ->
-    gen_server:cast(ServerRef, Message),
+    ServerRef ! Message,
     {reply, ok, State}.
 
 %% @private

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -35,6 +35,7 @@
          update_members/1,
          on_down/2,
          send_message/2,
+         cast_message/3,
          forward_message/3,
          receive_message/1,
          decode/1,
@@ -95,6 +96,12 @@ update_members(_Nodes) ->
 %% @doc Send message to a remote manager.
 send_message(Name, Message) ->
     gen_server:call(?MODULE, {send_message, Name, Message}, infinity).
+
+%% @doc Cast a message to a remote gen_server.
+cast_message(Name, ServerRef, Message) ->
+    FullMessage = {'$gen_cast', Message},
+    forward_message(Name, ServerRef, FullMessage).
+
 
 %% @doc Forward message to registered process on the remote side.
 forward_message(Name, ServerRef, Message) ->

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -100,7 +100,8 @@ send_message(Name, Message) ->
 %% @doc Cast a message to a remote gen_server.
 cast_message(Name, ServerRef, Message) ->
     FullMessage = {'$gen_cast', Message},
-    forward_message(Name, ServerRef, FullMessage).
+    forward_message(Name, ServerRef, FullMessage),
+    ok.
 
 
 %% @doc Forward message to registered process on the remote side.

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -860,6 +860,8 @@ stop(Nodes) ->
         case ct_slave:stop(Name) of
             {ok, _} ->
                 ok;
+            {error, stop_timeout, _} ->
+                ok;
             Error ->
                 ct:fail(Error)
         end

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -754,7 +754,7 @@ start(_Case, Config, Options) ->
                                        [fun() ->
                                             lists:foreach(fun(_) ->
                                                 receive
-                                                    {'$gen_cast', {store, N}} ->
+                                                    {store, N} ->
                                                         %% save the number in the environment
                                                         application:set_env(partisan, forward_message_test, N)
                                                 end


### PR DESCRIPTION
Some applications will need to forward messages on to processes where the remote side is not necessarily a gen_server.

- [x] Ensure cast returns 'ok' to match existing API.