### PR TITLE
Add support for monotonic channels.

### DIFF
--- a/src/partisan_peer_connection.erl
+++ b/src/partisan_peer_connection.erl
@@ -71,25 +71,22 @@ accept(TCPSocket) ->
 %% @see gen_tcp:send/2
 %% @see ssl:send/2
 -spec send(connection(), iodata()) -> ok | {error, reason()}.
-send(#connection{socket = Socket, transport = Transport, monotonic = Monotonic}, Data) ->
-    case Monotonic of
-        true ->
-            %% Get the current message queue length.
-            {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+send(#connection{socket = Socket, transport = Transport, monotonic = true}, Data) ->
+    %% Get the current message queue length.
+    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
 
-            %% Get last transmission time.
-            LastTransmissionTime = get(last_transmission_time),
+    %% Get last transmission time.
+    LastTransmissionTime = get(last_transmission_time),
 
-            %% Test for whether we should send or not.
-            case monotonic_should_send(MessageQueueLen, LastTransmissionTime) of
-                false ->
-                    ok;
-                true ->
-                    send(Transport, Socket, Data)
-            end;
+    %% Test for whether we should send or not.
+    case monotonic_should_send(MessageQueueLen, LastTransmissionTime) of
         false ->
+            ok;
+        true ->
             send(Transport, Socket, Data)
-    end.
+    end;
+send(#connection{socket = Socket, transport = Transport, monotonic = false}, Data) ->
+    send(Transport, Socket, Data).
 
 %% @see gen_tcp:recv/2
 %% @see ssl:recv/2

--- a/src/partisan_peer_connection.erl
+++ b/src/partisan_peer_connection.erl
@@ -39,12 +39,12 @@
 -record(connection, {
           socket :: gen_tcp:socket() | ssl:sslsocket(),
           transport :: gen_tcp | ssl,
-          control :: inet | ssl
+          control :: inet | ssl,
+          monotonic :: boolean()
          }).
 
 -type connection() :: #connection{}.
 -export_type([connection/0]).
-
 
 %% @doc Wraps a TCP socket with the appropriate information for
 %% transceiving on and controlling the socket later. If TLS/SSL is
@@ -63,16 +63,33 @@ accept(TCPSocket) ->
             {ok, TLSSocket} = ssl:ssl_accept(TCPSocket, TLSOpts),
             %% restore the expected active once setting
             ssl:setopts(TLSSocket, [{active, once}]),
-            #connection{socket = TLSSocket, transport = ssl, control = ssl};
+            #connection{socket = TLSSocket, transport = ssl, control = ssl, monotonic = false};
         _ ->
-            #connection{socket = TCPSocket, transport = gen_tcp, control = inet}
+            #connection{socket = TCPSocket, transport = gen_tcp, control = inet, monotonic = false}
     end.
 
 %% @see gen_tcp:send/2
 %% @see ssl:send/2
 -spec send(connection(), iodata()) -> ok | {error, reason()}.
-send(#connection{socket = Socket, transport = Transport}, Data) ->
-    Transport:send(Socket, Data).
+send(#connection{socket = Socket, transport = Transport, monotonic = Monotonic}, Data) ->
+    case Monotonic of
+        true ->
+            %% Get the current message queue time.
+            {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+
+            %% TODO: Get last send time.
+            LastTransmissionTime = get(last_transmission_time),
+
+            %% Test for whether we should send or not.
+            case monotonic_should_send(MessageQueueLen, LastTransmissionTime) of
+                false ->
+                    ok;
+                true ->
+                    send(Transport, Socket, Data)
+            end;
+        _ ->
+            send(Transport, Socket, Data)
+    end.
 
 %% @see gen_tcp:recv/2
 %% @see ssl:recv/2
@@ -119,7 +136,7 @@ connect(Address, Port, Options, Timeout) ->
 socket(Conn) ->
     Conn#connection.socket.
 
-%% Internal
+%% @private
 do_connect(Address, Port, Options, Timeout, Transport, Control) ->
    case Transport:connect(Address, Port, Options, Timeout) of
        {ok, Socket} ->
@@ -128,8 +145,45 @@ do_connect(Address, Port, Options, Timeout, Transport, Control) ->
            Error
    end.
 
+%% @private
 tls_enabled() ->
     partisan_config:get(tls).
 
+%% @private
 tls_options() ->
     partisan_config:get(tls_options).
+
+%% @private
+send(Transport, Socket, Data) ->
+    %% Update last transmission time.
+    put(last_transmission_time, erlang:monotonic_time(millisecond)),
+
+    %% Transmit the data on the socket.
+    Transport:send(Socket, Data).
+
+%% Determine if we should transmit:
+%%
+%% If theré's another message in the queue, we can skip 
+%% sending this message.  However, if the arrival rate of 
+%% messages is too high, we risk starvation where
+%% we may never send.  Therefore, we must force a transmission 
+%% after a given period with no transmissions.
+%%
+%% @private
+monotonic_should_send(MessageQueueLen, LastTransmissionTime) ->
+    case length(MessageQueueLen) > 0 of
+        true ->
+            NowTime = erlang:monotonic_time(millisecond),
+            Diff = abs(NowTime - LastTransmissionTime),
+
+            SendWindow = partisan_config:get(send_window, 1000),
+
+            case Diff > SendWindow of
+                true ->
+                    true;
+                false ->
+                    false
+            end;
+        false ->
+            true
+    end.

--- a/src/partisan_peer_connection.erl
+++ b/src/partisan_peer_connection.erl
@@ -167,7 +167,7 @@ send(Transport, Socket, Data) ->
 
 %% Determine if we should transmit:
 %%
-%% If theré's another message in the queue, we can skip 
+%% If there's another message in the queue, we can skip 
 %% sending this message.  However, if the arrival rate of 
 %% messages is too high, we risk starvation where
 %% we may never send.  Therefore, we must force a transmission 

--- a/src/partisan_peer_connection.erl
+++ b/src/partisan_peer_connection.erl
@@ -87,7 +87,7 @@ send(#connection{socket = Socket, transport = Transport, monotonic = Monotonic},
                 true ->
                     send(Transport, Socket, Data)
             end;
-        _ ->
+        false ->
             send(Transport, Socket, Data)
     end.
 
@@ -140,7 +140,7 @@ socket(Conn) ->
 do_connect(Address, Port, Options, Timeout, Transport, Control) ->
    case Transport:connect(Address, Port, Options, Timeout) of
        {ok, Socket} ->
-           {ok, #connection{socket = Socket, transport = Transport, control = Control}};
+           {ok, #connection{socket = Socket, transport = Transport, control = Control, monotonic = false}};
        Error ->
            Error
    end.

--- a/src/partisan_peer_connection.erl
+++ b/src/partisan_peer_connection.erl
@@ -184,14 +184,7 @@ monotonic_should_send(MessageQueueLen, LastTransmissionTime) ->
 
             SendWindow = partisan_config:get(send_window, 1000),
 
-            case Diff > SendWindow of
-                true ->
-                    %% We haven't sent recently enough; transmit.
-                    true;
-                false ->
-                    %% We sent within the window; ignore.
-                    false
-            end;
+            Diff > SendWindow;
         false ->
             %% No messages in queue; transmit.
             true


### PR DESCRIPTION
If a node has a monotonic channel to another node, only dispatch the last message from a process that could contain an overloaded mailbox.

Periodically, ensure that a message is sent to prevent the obvious race condition where messages are being delivered too fast, dropped, and no transmissions occur.