### PR TITLE
Don't crash when using multiple addresses

### DIFF
--- a/src/partisan_pool_sup.erl
+++ b/src/partisan_pool_sup.erl
@@ -46,7 +46,8 @@ init([]) ->
 
 %% @private
 socket(#{ip := IP, port := Port}) ->
-    #{id => partisan_socket, start => {partisan_socket, start_link, [IP, Port]}}.
+    #{id => {partisan_socket, IP, Port},
+      start => {partisan_socket, start_link, [IP, Port]}}.
 
 %% @private
 pool() ->

--- a/src/partisan_socket.erl
+++ b/src/partisan_socket.erl
@@ -39,7 +39,7 @@
 %% public api
 
 start_link(PeerIP, PeerPort) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [PeerIP, PeerPort], []).
+    gen_server:start_link(?MODULE, [PeerIP, PeerPort], []).
 
 %% gen_server api
 


### PR DESCRIPTION
One partisan_socket process is launched for every
listen address, this means there must be a different
id per supervisor spec and each process must not
register it's name.