### PR TITLE
Fix cluster leaves.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,11 @@ ct:
 shell:
 	${REBAR} shell --apps partisan
 
-logs:
+tail-logs:
 	tail -F priv/lager/*/log/*.log
+
+logs:
+	cat priv/lager/*/log/*.log
 
 ##
 ## Release targets

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -112,6 +112,7 @@ groups() ->
 
      {simple, [],
       [default_manager_test,
+       leave_test,
        on_down_test,
        client_server_manager_test]},
 
@@ -185,6 +186,106 @@ on_down_test(Config) ->
         ?TIMEOUT ->
             ct:fail("Didn't receive down callback.")
     end,
+
+    %% Stop nodes.
+    stop(Nodes),
+
+    ok.
+
+leave_test(Config) ->
+    %% Use the default peer service manager.
+    Manager = partisan_default_peer_service_manager,
+
+    %% Specify servers.
+    Servers = node_list(1, "server", Config),
+
+    %% Specify clients.
+    Clients = node_list(?CLIENT_NUMBER, "client", Config),
+
+    %% Start nodes.
+    Nodes = start(default_manager_test, Config,
+                  [{partisan_peer_service_manager, Manager},
+                   {servers, Servers},
+                   {clients, Clients}]),
+
+    %% Pause for clustering.
+    timer:sleep(1000),
+
+    %% Verify membership.
+    %%
+    %% Every node should know about every other node in this topology.
+    %%
+    VerifyInitialFun = fun({_, Node}) ->
+            {ok, Members} = rpc:call(Node, Manager, members, []),
+            SortedNodes = lists:usort([N || {_, N} <- Nodes]),
+            SortedMembers = lists:usort(Members),
+            case SortedMembers =:= SortedNodes of
+                true ->
+                    true;
+                false ->
+                    ct:pal("Membership incorrect; node ~p should have ~p but has ~p",
+                           [Node, SortedNodes, SortedMembers]),
+                    {false, {Node, SortedNodes, SortedMembers}}
+            end
+    end,
+
+    %% Verify the membership is correct.
+    lists:foreach(fun(Node) ->
+                          VerifyNodeFun = fun() -> VerifyInitialFun(Node) end,
+
+                          case wait_until(VerifyNodeFun, 60 * 2, 100) of
+                              ok ->
+                                  ok;
+                              {fail, {false, {Node, Expected, Contains}}} ->
+                                 ct:fail("Membership incorrect; node ~p should have ~p but has ~p",
+                                         [Node, Expected, Contains])
+                          end
+                  end, Nodes),
+
+    %% Remove a node from the cluster.
+    [{_, _}, {_, Node2}, {_, _}, {_, Node4}] = Nodes,
+    ct:pal("Removing node ~p from the cluster.", [Node4]),
+    ok = rpc:call(Node2, partisan_peer_service, leave, [Node4]),
+    
+    %% Pause for clustering.
+    timer:sleep(2000),
+
+    %% Verify membership.
+    %%
+    %% Every node should know about every other node in this topology.
+    %%
+    VerifyRemoveFun = fun({_, Node}) ->
+            {ok, Members} = rpc:call(Node, Manager, members, []),
+            SortedNodes = case Node of
+                Node4 ->
+                    [Node4];
+                _ ->
+                    lists:usort([N || {_, N} <- Nodes]) -- [Node4]
+            end,
+            SortedMembers = lists:usort(Members),
+            case SortedMembers =:= SortedNodes of
+                true ->
+                    true;
+                false ->
+                    ct:pal("Membership incorrect; node ~p should have ~p but has ~p",
+                           [Node, SortedNodes, SortedMembers]),
+                    {false, {Node, SortedNodes, SortedMembers}}
+            end
+    end,
+
+    %% Verify the membership is correct.
+    lists:foreach(fun(Node) ->
+                          VerifyNodeFun = fun() -> VerifyRemoveFun(Node) end,
+
+                          case wait_until(VerifyNodeFun, 60 * 2, 100) of
+                              ok ->
+                                  ok;
+                              {fail, {false, {Node, Expected, Contains}}} ->
+                                 ct:fail("Membership incorrect; node ~p should have ~p but has ~p",
+                                         [Node, Expected, Contains])
+                          end
+                  end, Nodes),
+
 
     %% Stop nodes.
     stop(Nodes),


### PR DESCRIPTION
When leaving, don't shutdown, but reset membership back to node only.  Ensure gossip always uses all peers, because a random fanout doesn't guarantee that a leaving node will observe itself leaving the cluster immediately.