### PR TITLE
Handle leaves properly.

### DIFF
--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -306,7 +306,7 @@ handle_call({leave, Node}, From, #state{actor=Actor}=State0) ->
             EmptyMembership = empty_membership(Actor),
             persist_state(EmptyMembership),
 
-            {reply, ok, State#state{membership=EmptyMembership}};
+            {stop, normal, State#state{membership=EmptyMembership}};
         _ ->
             {reply, ok, State}
     end;

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -296,15 +296,17 @@ handle_call({leave, Node}, From, #state{actor=Actor}=State0) ->
     %% Perform leave.
     State = internal_leave(Node, State0),
 
-    %% Remove state and shutdown if we are removing ourselves.
     case node() of
         Node ->
             gen_server:reply(From, ok),
 
-            Membership = empty_membership(Actor),
-            persist_state(Membership),
+            %% Reset membership, normal terminate on the gen_server:
+            %% this will close all connections, restart the gen_server,
+            %% and reboot with empty state, so the node will be isolated.
+            EmptyMembership = empty_membership(Actor),
+            persist_state(EmptyMembership),
 
-            {reply, ok, State};
+            {reply, ok, State#state{membership=EmptyMembership}};
         _ ->
             {reply, ok, State}
     end;
@@ -593,7 +595,7 @@ establish_connections(Pending,
     Connections.
 
 %% @private
-handle_message({receive_state, PeerMembership},
+handle_message({receive_state, #{name := From}, PeerMembership},
                #state{actor=Actor,
                       pending=Pending,
                       membership=Membership,
@@ -623,16 +625,23 @@ handle_message({receive_state, PeerMembership},
                                                         Membership,
                                                         Connections0),
 
+                    lager:info("Received updated membership state: ~p from ~p", [Members, From]),
+
                     %% Gossip.
                     do_gossip(Membership, Connections),
 
                     {reply, ok, State#state{membership=Merged,
                                             connections=Connections}};
                 false ->
+                    lager:info("Node ~p is no longer part of the cluster, setting empty membership.", [node()]),
+
+                    %% Reset membership, normal terminate on the gen_server:
+                    %% this will close all connections, restart the gen_server,
+                    %% and reboot with empty state, so the node will be isolated.
                     EmptyMembership = empty_membership(Actor),
                     persist_state(EmptyMembership),
 
-                    {reply, ok, State#state{membership=EmptyMembership}}
+                    {stop, normal, State#state{membership=EmptyMembership}}
             end
     end;
 handle_message({forward_message, ServerRef, Message}, State) ->
@@ -675,10 +684,14 @@ do_gossip(Recipients, Membership, Connections) ->
                 [] ->
                     ok;
                 AllPeers ->
+                    Members = [N || #{name := N} <- members(Membership)],
+
+                    lager:info("Sending state with updated membership: ~p", [Members]),
+
                     lists:foreach(fun(Peer) ->
                                 do_send_message(Peer,
                                                 ?DEFAULT_CHANNEL,
-                                                {receive_state, Membership},
+                                                {receive_state, myself(), Membership},
                                                 Connections)
                         end, AllPeers),
                     ok
@@ -743,6 +756,8 @@ down(Name, #state{down_functions=DownFunctions}) ->
 internal_leave(Node, #state{actor=Actor,
                             connections=Connections,
                             membership=Membership0}=State) ->
+    lager:info("Leaving node ~p at node ~p", [Node, node()]),
+
     %% Node may exist in the membership on multiple ports, so we need to
     %% remove all.
     Membership = lists:foldl(fun(#{name := Name} = N, M0) ->

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -209,8 +209,8 @@ rejoin_test(Config) ->
                    {servers, Servers},
                    {clients, Clients}]),
 
-    %% Pause for clustering.
-    timer:sleep(2000),
+    %% Pause for gossip interval * node exchanges + gossip interval for full convergence.
+    timer:sleep(?GOSSIP_INTERVAL * length(Nodes) + ?GOSSIP_INTERVAL),
 
     %% Verify membership.
     %%
@@ -248,8 +248,8 @@ rejoin_test(Config) ->
     ct:pal("Removing node ~p from the cluster.", [Node4]),
     ok = rpc:call(Node2, partisan_peer_service, leave, [Node4]),
     
-    %% Pause for clustering.
-    timer:sleep(3000),
+    %% Pause for gossip interval * node exchanges + gossip interval for full convergence.
+    timer:sleep(?GOSSIP_INTERVAL * length(Nodes) + ?GOSSIP_INTERVAL),
 
     %% Verify membership.
     %%
@@ -292,8 +292,8 @@ rejoin_test(Config) ->
     ct:pal("Joining node ~p to the cluster.", [Node4]),
     ok = rpc:call(Node2, partisan_peer_service, join, [Node4]),
     
-    %% Pause for clustering.
-    timer:sleep(3000),
+    %% Pause for gossip interval * node exchanges + gossip interval for full convergence.
+    timer:sleep(?GOSSIP_INTERVAL * length(Nodes) + ?GOSSIP_INTERVAL),
 
     %% Verify membership.
     %%

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -114,6 +114,7 @@ groups() ->
      {simple, [],
       [default_manager_test,
        leave_test,
+       rejoin_test,
        on_down_test,
        client_server_manager_test]},
 

--- a/test/partisan_SUITE.erl
+++ b/test/partisan_SUITE.erl
@@ -41,6 +41,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
+-define(GOSSIP_INTERVAL, 1000).
 -define(TIMEOUT, 10000).
 -define(CLIENT_NUMBER, 3).
 
@@ -346,8 +347,8 @@ leave_test(Config) ->
                    {servers, Servers},
                    {clients, Clients}]),
 
-    %% Pause for clustering.
-    timer:sleep(1000),
+    %% Pause for gossip interval * node exchanges + gossip interval for full convergence.
+    timer:sleep(?GOSSIP_INTERVAL * length(Nodes) + ?GOSSIP_INTERVAL),
 
     %% Verify membership.
     %%
@@ -385,8 +386,8 @@ leave_test(Config) ->
     ct:pal("Removing node ~p from the cluster.", [Node4]),
     ok = rpc:call(Node2, partisan_peer_service, leave, [Node4]),
     
-    %% Pause for clustering.
-    timer:sleep(2000),
+    %% Pause for gossip interval * node exchanges + gossip interval for full convergence.
+    timer:sleep(?GOSSIP_INTERVAL * length(Nodes) + ?GOSSIP_INTERVAL),
 
     %% Verify membership.
     %%
@@ -1042,6 +1043,9 @@ start(_Case, Config, Options) ->
             MaxActiveSize = proplists:get_value(max_active_size, Options, 5),
             ok = rpc:call(Node, partisan_config, set,
                           [max_active_size, MaxActiveSize]),
+                          
+            ok = rpc:call(Node, partisan_config, set,
+                          [gossip_interval, ?GOSSIP_INTERVAL]),
 
             ok = rpc:call(Node, application, set_env, [partisan, peer_ip, ?PEER_IP]),
 


### PR DESCRIPTION
If a node receives a message that it's supposed to be evicted from the cluster, it needs to reset it's state, shutdown and restart, thereby clearing all connections, before it can hear about old state on a existing open channel -- otherwise, that state will be merged back in and the node will never actually leave the cluster.