### PR TITLE
Attempt to receive message without serializing.

### DIFF
--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -155,6 +155,14 @@ forward_message(Name, Channel, ServerRef, Message) ->
     end.
 
 %% @doc Receive message from a remote manager.
+receive_message({forward_message, ServerRef, Message}) ->
+    try
+        ServerRef ! Message
+    catch
+        _:Error ->
+            lager:info("Error forwarding message ~p to process ~p: ~p", [Message, ServerRef, Error])
+    end,
+    ok;
 receive_message(Message) ->
     gen_server:call(?MODULE, {receive_message, Message}, infinity).
 


### PR DESCRIPTION
Don't serialize on the backend when receiving a message: this causes an
additional message copy and induces serialization where not necessary.