### PR TITLE
fix result

### DIFF
--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -415,8 +415,7 @@ maybe_load_state_from_disk() ->
             case filelib:is_regular(filename:join(Dir, "cluster_state")) of
                 true ->
                     {ok, Bin} = file:read_file(filename:join(Dir, "cluster_state")),
-                    {ok, State} = binary_to_term(Bin),
-                    State;
+                    binary_to_term(Bin);
                 false ->
                     empty_membership()
             end


### PR DESCRIPTION
when writing data using `term_to_binary`, and loading from disk, I think using `binary_to_term` just decode the data out, not match the `{ok, State}` pattern.