### PR TITLE
Fixes to membership state when nodes explicitly leave (partisan_default_peer_service)

### DIFF
--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -246,7 +246,7 @@ init([]) ->
                         erlang:unique_integer()}),
 
     case partisan_config:get(binary_padding, false) of
-        true ->    
+        true ->
             %% Use 64-byte binary to force shared heap usage to cut down on copying.
             BinaryPaddingTerm = rand_bits(512),
             partisan_config:set(binary_padding_term, BinaryPaddingTerm);
@@ -354,6 +354,9 @@ handle_call({leave, Node}, From, #state{actor=Actor}=State0) ->
             EmptyMembership = empty_membership(Actor),
             persist_state(EmptyMembership),
 
+            %% Update users of the peer service.
+            partisan_peer_service_events:update(EmptyMembership),
+
             {stop, normal, State#state{membership=EmptyMembership}};
         _ ->
             {reply, ok, State}
@@ -393,10 +396,10 @@ handle_call({sync_join, #{name := Name} = Node},
 
 handle_call({send_message, Name, Channel, Message}, _From,
             #state{connections=Connections}=State) ->
-    Result = do_send_message(Name, 
-                             Channel, 
-                             ?DEFAULT_PARTITION_KEY, 
-                             Message, 
+    Result = do_send_message(Name,
+                             Channel,
+                             ?DEFAULT_PARTITION_KEY,
+                             Message,
                              Connections),
     {reply, Result, State};
 

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -675,13 +675,13 @@ handle_message({receive_state, #{name := From}, PeerMembership},
                 true ->
                     %% Establish any new connections.
                     Connections = establish_connections(Pending,
-                                                        Membership,
+                                                        Merged,
                                                         Connections0),
 
                     lager:debug("Received updated membership state: ~p from ~p", [Members, From]),
 
                     %% Gossip.
-                    do_gossip(Membership, Connections),
+                    do_gossip(Merged, Connections),
 
                     {reply, ok, State#state{membership=Merged,
                                             connections=Connections}};

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -642,7 +642,7 @@ establish_connections(Pending,
     %% Reconnect disconnected members and members waiting to join.
     Connections = lists:foldl(fun(Peer, Cs) ->
                                 partisan_util:maybe_connect(Peer, Cs)
-                              end, Connections0, without_me(Peers)),
+                              end, Connections0, Peers),
 
     %% Return the updated list of connections.
     Connections.

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -359,6 +359,8 @@ handle_call({leave, Node}, From, #state{actor=Actor}=State0) ->
 
             {stop, normal, State#state{membership=EmptyMembership}};
         _ ->
+            %% Update users of the peer service.
+            partisan_peer_service_events:update(State#state.membership),
             {reply, ok, State}
     end;
 
@@ -696,6 +698,9 @@ handle_message({receive_state, #{name := From}, PeerMembership},
                     %% and reboot with empty state, so the node will be isolated.
                     EmptyMembership = empty_membership(Actor),
                     persist_state(EmptyMembership),
+
+                    %% Update users of the peer service.
+                    partisan_peer_service_events:update(EmptyMembership),
 
                     {stop, normal, State#state{membership=EmptyMembership}}
             end


### PR DESCRIPTION
I found a number of issues when using `partisan_default_peer_service_manager:leave/0`.


* In `partisan_default_peer_service_manager:handle_message({receive_state, ...}, ...)` the functions `establish_connections/4` and `do_gossip/2` where called with the previous membership Set as opposed to the newly merged Set. 
* In `partisan_default_peer_service_manager:handle_call({leave, Node}, ...)` I added a call to `partisan_peer_service_events:update(EmptyMembership),` to fix an issue where peer service users would not get notified of the membership change. This might look redundant as the sever stops right after that call, but Plumtree for example will miss the update and keep and incorrect view of the `broadcast_members`.
* Removed a redundant call to `without_me` in `partisan_default_peer_service_manager:establish_connections/4`.



### Outstanding issues
In a two node cluster (I use as example our app called `plum_db`), after node `plum_db2` leaves the cluster with `partisan_default_peer_service_manager:leave/0`, we still end up with an inconsistent connection state.

```erlang
(plum_db2@127.0.0.1)6> partisan_default_peer_service_manager:connections().
{ok,{dict,0,16,16,8,80,48,
          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
          {{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}}
```

Which is correct, but `plum_db1` still has a connection to `plum_db2` (??).

```erlang
(plum_db1@127.0.0.1)4> partisan_default_peer_service_manager:connections().
{ok,{dict,1,16,16,8,80,48,
          {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},
          {{[],[],[],[],[],[],[],
            [[#{channels => [undefined],
                listen_addrs =>
                    [#{ip => {127,0,0,...},port => 51974}],
                name => 'plum_db2@127.0.0.1',parallelism => 1},
              {#{ip => {127,0,0,1},port => 51974},
               undefined,<0.847.0>}]],
            [],[],[],[],[],[],[],[]}}}}
```

I think the issue is that we need to manually kill the connections on the `handle_call({leave, Node},...)` call? with a call to `partisan_util:may_disconnect/2` ?

I will create an Issue if this last thing makes sense and try to find a solution later.
