### PR TITLE
display connect error as warning

### DIFF
--- a/src/partisan_peer_service_client.erl
+++ b/src/partisan_peer_service_client.erl
@@ -69,8 +69,8 @@ init([Peer, ListenAddr, Channel, From]) ->
 
             {ok, #state{from=From, listen_addr=ListenAddr, channel=Channel, socket=Socket, peer=Peer}};
         Error ->
-            lager:error("unable to connect to ~p due to ~p",
-                        [Peer, Error]),
+            lager:warning("unable to connect to ~p due to ~p",
+                          [Peer, Error]),
             {stop, normal}
     end.
 


### PR DESCRIPTION
instead of logging it as an error, display a warning when connecting the client