### PR TITLE
Make sync_join synchronous.

### DIFF
--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -440,7 +440,7 @@ handle_call({sync_join, #{name := Name} = Node},
             State = sync_internal_join(Node, From, State0),
 
             %% Return.
-            {reply, ok, State}
+            {noreply, State}
     end;
 
 handle_call({send_message, Name, Channel, Message}, _From,


### PR DESCRIPTION
Fix the sync_join command so that the call is actually synchronous.