### PR TITLE
use net kernel connect node

### DIFF
--- a/src/partisan_client_server_peer_service_manager.erl
+++ b/src/partisan_client_server_peer_service_manager.erl
@@ -263,7 +263,7 @@ handle_call({join, #{name := Name}=Node},
             _From,
             #state{pending=Pending0, connections=Connections0}=State) ->
     %% Attempt to join via disterl for control messages during testing.
-    _ = net_kernel:connect(Name),
+    _ = net_kernel:connect_node(Name),
 
     %% Add to list of pending connections.
     Pending = [Node|Pending0],

--- a/src/partisan_default_peer_service_manager.erl
+++ b/src/partisan_default_peer_service_manager.erl
@@ -1035,7 +1035,7 @@ internal_leave(Node, #state{actor=Actor,
 %% @private
 internal_join(Node, State) when is_atom(Node) ->
     %% Maintain disterl connection for control messages.
-    _ = net_kernel:connect(Node),
+    _ = net_kernel:connect_node(Node),
 
     %% Get listen addresses.
     ListenAddrs = rpc:call(Node, partisan_config, listen_addrs, []),
@@ -1056,7 +1056,7 @@ internal_join(#{name := Name} = Node,
                      connections=Connections0,
                      membership=Membership}=State) ->
     %% Maintain disterl connection for control messages.
-    _ = net_kernel:connect(Name),
+    _ = net_kernel:connect_node(Name),
 
     %% Add to list of pending connections.
     Pending = [Node|Pending0],
@@ -1080,7 +1080,7 @@ sync_internal_join(#{name := Name} = Node,
                      connections=Connections0,
                      membership=Membership}=State) ->
     %% Maintain disterl connection for control messages.
-    _ = net_kernel:connect(Name),
+    _ = net_kernel:connect_node(Name),
 
     %% Add to list of pending connections.
     Pending = [Node|Pending0],

--- a/src/partisan_static_peer_service_manager.erl
+++ b/src/partisan_static_peer_service_manager.erl
@@ -218,7 +218,7 @@ handle_call({join, #{name := Name}=Node},
             _From,
             #state{pending=Pending0, connections=Connections0}=State) ->
     %% Attempt to join via disterl for control messages during testing.
-    _ = net_kernel:connect(Name),
+    _ = net_kernel:connect_node(Name),
 
     %% Add to list of pending connections.
     Pending = [Node|Pending0],


### PR DESCRIPTION
net_kernel:connect/1 is missing in erlang/otp 21, use the net_kernel:connect_node/1 instead.
And add net_kernel app to dialyzer anlysis.