### PR TITLE
Change persist epoch

### DIFF
--- a/src/partisan_hyparview_peer_service_manager.erl
+++ b/src/partisan_hyparview_peer_service_manager.erl
@@ -1494,7 +1494,7 @@ merge_exchange(Exchange, #state{myself=Myself, active=Active}=State0) ->
 
 %% @private
 notify(#state{active=Active}) ->
-    partisan_peer_service_events:update(Active).
+    catch partisan_peer_service_events:update(Active).
 
 %% @private
 reserved_slot_available(Tag, Reserved) ->

--- a/src/partisan_peer_service_connections.erl
+++ b/src/partisan_peer_service_connections.erl
@@ -176,7 +176,7 @@ prune_connections_test() ->
     ?assertEqual({ok, [node1_bind()]}, find(node1(), Connections3)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections4} = prune(self(), Connections3),
-    ?assertEqual({ok, []}, find(node1(), Connections4)),
+    ?assertEqual({error, not_found}, find(node1(), Connections4)),
     Connections5 = store(node1(), node1_bind(), Connections4),
     Connections6 = store(node1(), node1_bind(), Connections5),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
@@ -184,7 +184,7 @@ prune_connections_test() ->
     ?assertEqual({ok, [node1_bind()]}, find(node1, Connections7)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections8} = prune(self(), Connections7),
-    ?assertEqual({ok, []}, find(node1, Connections8)).
+    ?assertEqual({error, not_found}, find(node1, Connections8)).
 
 add_remove_add_connection_test() ->
     Connections0 = new(),
@@ -192,11 +192,11 @@ add_remove_add_connection_test() ->
     ?assertEqual({ok, [node1_bind()]}, find(node1, Connections1)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections2} = prune(self(), Connections1),
-    ?assertEqual({ok, []}, find(node1, Connections2)),
+    ?assertEqual({error, not_found}, find(node1, Connections2)),
     Connections3 = store(node1(), node1_bind(), Connections2),
     ?assertEqual({ok, [node1_bind()]}, find(node1, Connections3)),
     {#{name := node1, listen_addrs := [#{ip := {127, 0, 0, 1}, port := 80}]},
      Connections4} = prune(node1(), Connections3),
-    ?assertEqual({ok, []}, find(node1, Connections4)).
+    ?assertEqual({error, not_found}, find(node1, Connections4)).
 
 -endif.


### PR DESCRIPTION
I recheck the code for many times, and find that, the manager process dies and restarts, the connections are all lost, but the active and the passive are still remained. So the other network close, the active will not be deleted and not correct.The solution I think is only persist the epoch. 
The xbot module does have the same problem, I don’t know the solution is correct or not,  if the pr is merged, I will make a new pr to the xbot module.
Feedback is needed.