### PR TITLE
Address X-BOT regression and race condition.

### DIFF
--- a/include/partisan.hrl
+++ b/include/partisan.hrl
@@ -31,8 +31,7 @@
 -type node_spec() :: #{name => node(),
                        listen_addrs => [listen_addr()],
                        channels => [channel()],
-                       parallelism => non_neg_integer(),
-                       xbot_interval => non_neg_integer()}.
+                       parallelism => non_neg_integer()}.
 -type message() :: term().
 -type name() :: node().
 -type partitions() :: [{reference(), node_spec()}].

--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -75,6 +75,9 @@ init() ->
     DefaultPeerIP = try_get_node_address(),
     DefaultPeerPort = random_port(),
 
+    %% Configure X-BOT interval.
+    XbotInterval = rand:uniform(?XBOT_RANGE_INTERVAL) + ?XBOT_MIN_INTERVAL, 
+
     [env_or_default(Key, Default) ||
         {Key, Default} <- [{arwl, 5},
                            {prwl, 30},
@@ -107,7 +110,8 @@ init() ->
                            {reservations, []},
                            {tls, false},
                            {tls_options, []},
-                           {tag, DefaultTag}]],
+                           {tag, DefaultTag},
+                           {xbot_interval, XbotInterval}]],
 
     %% Setup default listen addr.
     DefaultListenAddrs = [#{ip => ?MODULE:get(peer_ip), port => ?MODULE:get(peer_port)}],

--- a/src/partisan_hyparview_xbot_peer_service_manager.erl
+++ b/src/partisan_hyparview_xbot_peer_service_manager.erl
@@ -1763,9 +1763,11 @@ schedule_passive_view_maintenance() ->
 
 %% @private
 schedule_xbot_execution(#{xbot_interval := Interval}) ->
+    Interval = partisan_config:get(xbot_interval),
+
 	erlang:send_after(Interval,
-						?MODULE,
-						xbot_execution).
+				  	  ?MODULE,
+					  xbot_execution).
 
 %% @reference http://stackoverflow.com/questions/8817171/shuffling-elements-in-a-list-randomly-re-arrange-list-elements/8820501#8820501
 shuffle(L) ->

--- a/src/partisan_hyparview_xbot_peer_service_manager.erl
+++ b/src/partisan_hyparview_xbot_peer_service_manager.erl
@@ -284,7 +284,7 @@ init([]) ->
     schedule_passive_view_maintenance(),
 
     %% Schedule periodic execution of xbot algorithm (optimization)
-    schedule_xbot_execution(Myself),
+    schedule_xbot_execution(),
 
     %% Schedule tree peers refresh.
     schedule_tree_refresh(),
@@ -579,8 +579,7 @@ handle_info(passive_view_maintenance,
 
 % handle optimization using xbot algorithm
 handle_info(xbot_execution,
-				#state{myself=Myself,
-					   active=Active,
+				#state{active=Active,
 					   passive=Passive,
 					   max_active_size=MaxActiveSize,
 					   reserved=Reserved}=InitiatorState) ->
@@ -597,7 +596,7 @@ handle_info(xbot_execution,
 	end,
 
 	%In any case, schedule periodic xbot execution algorithm (optimization)
-	schedule_xbot_execution(Myself),
+	schedule_xbot_execution(),
 	{noreply, InitiatorState};
 
 handle_info({'EXIT', From, Reason},

--- a/src/partisan_hyparview_xbot_peer_service_manager.erl
+++ b/src/partisan_hyparview_xbot_peer_service_manager.erl
@@ -1762,7 +1762,7 @@ schedule_passive_view_maintenance() ->
                       passive_view_maintenance).
 
 %% @private
-schedule_xbot_execution(#{xbot_interval := Interval}) ->
+schedule_xbot_execution() ->
     Interval = partisan_config:get(xbot_interval),
 
 	erlang:send_after(Interval,

--- a/src/partisan_peer_service_manager.erl
+++ b/src/partisan_peer_service_manager.erl
@@ -72,8 +72,7 @@ myself() ->
     Channels = partisan_config:get(channels, ?CHANNELS),
     Name = partisan_config:get(name),
     ListenAddrs = partisan_config:get(listen_addrs),
-    XBotOptNodeInterval = rand:uniform(?XBOT_RANGE_INTERVAL)+?XBOT_MIN_INTERVAL,
-    #{name => Name, listen_addrs => ListenAddrs, channels => Channels, parallelism => Parallelism, xbot_interval => XBotOptNodeInterval}.
+    #{name => Name, listen_addrs => ListenAddrs, channels => Channels, parallelism => Parallelism}.
 
 mynode() ->
     partisan_config:get(name, node()).


### PR DESCRIPTION
Nodes performing a synchronous join will wait to proceed until they have established all outbound connections.  They will periodically check and unblock the join when all connections have been open.  However, this check only happens when receiving incoming connections, and therefore a race exists where the last node may join before all outgoing connections are established and thereby prevent the join from ever finishing.  To resolve, periodically check the blocked joins on the connection interval and unblock joins if they happen to be fulfilled (by opening of outgoing connections) at the next check interval.

However, this uncovered a further problem.  When the X-BOT backend was created, only some of the node specifications were modified to add the new X-BOT parameters, not all, therefore making it seem like nodes that didn't have them were distinct.  This meant that some of the connections that the system were blocked waiting to open were, in fact, already open and split across two different node specifications.  

(Too bad we don't have types to prevent something like this, :/)

We ended up with situtations like this:

```
2018-09-24 01:48:27.498 [info] <0.233.0>@partisan_default_peer_service_manager:fully_connected:1144 Node #{channels => [undefined,gossip,broadcast,vnode],listen_addrs => [#{ip => {127,0,0,1},port => 64825}],name => 'node_1@127.0.0.1',parallelism => 2} has 5 open connections, 8 required.
```

But, wait, all 8 connections are open?  They are; however, split across two different hosts.  It's the same host, but the system thinks they are distinct because of the different connection strings.

```
[#{channels => [undefined,gossip,broadcast,vnode],
   listen_addrs => [#{ip => {127,0,0,1},port => 64825}],
   name => 'node_1@127.0.0.1',parallelism => 2},
 #{channels => [undefined,gossip,broadcast,vnode],
   listen_addrs => [#{ip => {127,0,0,1},port => 64825}],
   name => 'node_1@127.0.0.1',parallelism => 2,
   xbot_interval => 63898}]
4>
```

For now, I've removed the X-BOT parameter from the specifications.  

This is a __breaking change__ for the X-BOT code, but necessary to resolve issues where the same host might appear as two different distinct hosts, thereby:

1.) preventing the symmetry in HyParView and limiting scalability (probably explains the test regressions with symmetry) and
2.) causing additional, unnecessary connections in the default manager, consuming unnecessary memory.