### PR TITLE
handle {via, Module, Name} tuple when receiving a message

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
         rand_compat,
         {acceptor_pool, "1.0.0-rc.0"},
         {types, "~> 0.1"},
-        {lager, "~> 3.5"}
+        {lager, "~> 3.6"}
        ]}.
 
 {dialyzer_base_plt_apps, [kernel, stdlib, erts, sasl, eunit, syntax_tools, compiler, crypto]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,20 +1,20 @@
 {"1.1.0",
 [{<<"acceptor_pool">>,{pkg,<<"acceptor_pool">>,<<"1.0.0-rc.0">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.5.1">>},0},
- {<<"quickrand">>,{pkg,<<"quickrand">>,<<"1.7.3">>},1},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.9">>},0},
+ {<<"quickrand">>,{pkg,<<"quickrand">>,<<"1.7.5">>},1},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.3">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
- {<<"types">>,{pkg,<<"types">>,<<"0.1.6">>},0},
- {<<"uuid">>,{pkg,<<"uuid_erl">>,<<"1.7.3">>},0}]}.
+ {<<"types">>,{pkg,<<"types">>,<<"0.1.8">>},0},
+ {<<"uuid">>,{pkg,<<"uuid_erl">>,<<"1.7.5">>},0}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"679D741DF87FC13599B1AEF2DF8F78F1F880449A6BEFAB7C44FB6FAE0E92A2DE">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"63897A61AF646C59BB928FEE9756CE8BDD02D5A1A2F3551D4A5E38386C2CC071">>},
- {<<"quickrand">>, <<"0E4FB48FAC904FE0C6E21D7E8C31A288A0700E1E81A35B38B649FC119079755D">>},
+ {<<"lager">>, <<"387BCD836DC0C8AD9C6D90A0E0CE5B29676847950CBC527BCCC194A02028DE8E">>},
+ {<<"quickrand">>, <<"E3086A153EB13A057FC19192D05E2D4C6BB2BDBB55746A699BEAE9847AC17CA8">>},
  {<<"rand_compat">>, <<"011646BC1F0B0C432FE101B816F25B9BBB74A085713CEE1DAFD2D62E9415EAD3">>},
  {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>},
- {<<"types">>, <<"03BB7140016C896D3441A77CB0B7D6ACAA583D6D6E9C4A3E1FD3C25123710290">>},
- {<<"uuid">>, <<"C5DF97D1A3D626235C2415E74053C47B2138BB863C5CD802AB5CAECB8ECC019F">>}]}
+ {<<"types">>, <<"5782B67231E8C174FE2835395E71E669FE0121076779D2A09F1C0D58EE0E2F13">>},
+ {<<"uuid">>, <<"3862FF9A21C42566DFD0376B97512FA202922897129E09A05E2AFA0D9CAFD97A">>}]}
 ].

--- a/src/partisan_util.erl
+++ b/src/partisan_util.erl
@@ -230,7 +230,7 @@ maybe_initiate_parallel_connections(Connections0, Channel, Node, ListenAddr, Par
 
 term_to_iolist(Term) ->
     [131, term_to_iolist_(Term)].
-        
+
 term_to_iolist_([]) ->
     106;
 term_to_iolist_({}) ->
@@ -305,6 +305,9 @@ process_forward(ServerRef, Message) ->
                 Pid ! Message;
             {global, Name} ->
                 Pid = global:whereis_name(Name),
+                Pid ! Message;
+            {via, Module, Name} ->
+                Pid =  Module:whereis_name(Name),
                 Pid ! Message;
             _ ->
                 ServerRef ! Message,


### PR DESCRIPTION
Like OTP gen_servers this changes brings support of the via syntax
allowing partisan to find a process registered through an alternative
process registry.