### PR TITLE
Fixes an out-of-sync issue between peer service membership state and local event handlers

### DIFF
--- a/src/partisan_plumtree_broadcast.erl
+++ b/src/partisan_plumtree_broadcast.erl
@@ -405,6 +405,7 @@ handle_graft({error, Reason}, _MessageId, Mod, _Round, _Root, _From, State) ->
 neighbors_down(Removed, State=#state{common_eagers=CommonEagers, eager_sets=EagerSets,
                                      common_lazys=CommonLazys, lazy_sets=LazySets,
                                      outstanding=Outstanding}) ->
+    NewAllMembers = ordsets:subtract(State#state.all_members, Removed),
     NewCommonEagers = ordsets:subtract(CommonEagers, Removed),
     NewCommonLazys  = ordsets:subtract(CommonLazys, Removed),
     %% TODO: once we have delayed grafting need to remove timers
@@ -417,7 +418,9 @@ neighbors_down(Removed, State=#state{common_eagers=CommonEagers, eager_sets=Eage
                                           orddict:erase(RPeer, OutstandingAcc)
                                   end,
                                   Outstanding, Removed),
-    State#state{common_eagers=NewCommonEagers,
+
+    State#state{all_members=NewAllMembers,
+                common_eagers=NewCommonEagers,
                 common_lazys=NewCommonLazys,
                 eager_sets=NewEagerSets,
                 lazy_sets=NewLazySets,


### PR DESCRIPTION
- `partisan_default_peer_service_manager.erl`
    - Added missing call to `partisan_peer_service_events:update/1`.
    - Without a call to `partisan_peer_service_events:update/1 in handle_call({leave, _}, _, _)` and `handle_message({receive_state, …})` local event handlers will not receive a membership state change event when the node leaves the cluster.

- `partisan_plumtree_broadcast.erl`
    - fixed missing update to #state.all_members after node removal.
    - Fixes an issue when a node removes itself from the cluster, the other nodes will still have a connection open to the leaving node.

Example:
In our case we add plum tree broadcast as an event handler for partisan's memberships state change events. We do this since we are using Plumtree's AAE.

```erlang
> partisan_peer_service:leave(partisan_peer_service_manager:mynode()).
> partisan_peer_service:members().
{ok,['plum_db1@127.0.0.1']}
> plumtree_broadcast:broadcast_members().
['plum_db1@127.0.0.1','plum_db2@127.0.0.1']
```