### PR TITLE
Basic version of remote monitoring

### DIFF
--- a/src/partisan_monitor.erl
+++ b/src/partisan_monitor.erl
@@ -1,3 +1,4 @@
+%% @doc This module is responsible for monitoring processes on remote nodes.
 -module(partisan_monitor).
 
 -behaviour(partisan_gen_server).
@@ -19,6 +20,10 @@
 start_link() ->
     partisan_gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+%% @doc when you attempt to monitor a partisan_remote_reference, it is not
+%% guaranteed that you will receive the DOWN message. A few reasons for not
+%% receiving the message are message loss, tree reconfiguration and the node
+%% is no longer reachable.
 monitor(Pid) when is_pid(Pid) ->
     erlang:monitor(pid);
 monitor({partisan_remote_reference, Node,

--- a/src/partisan_monitor.erl
+++ b/src/partisan_monitor.erl
@@ -1,0 +1,75 @@
+-module(partisan_monitor).
+
+-behaviour(partisan_gen_server).
+
+% API
+-export([start_link/0, monitor/1, demonitor/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+start_link() ->
+    partisan_gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+monitor({partisan_remote_reference, Node,
+         {partisan_process_reference, PidAsList}}) ->
+    partisan_gen_server:call({?MODULE, Node}, {monitor, PidAsList}).
+
+demonitor({partisan_remote_reference, Node,
+           {partisan_encoded_reference, _}} = PartisanRef) ->
+    partisan_gen_server:call({?MODULE, Node}, {demonitor, PartisanRef}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+init([]) ->
+    {ok, #{}}.
+
+%% @private
+handle_call({monitor, PidAsList}, {PartisanRemote, _PartisanRemoteRef}, State) ->
+    Ref = erlang:monitor(process, list_to_pid(PidAsList)),
+    PartisanRef = partisan_util:ref(Ref),
+    State1 = maps:put(Ref, {PartisanRef, PartisanRemote}, State),
+    StateFinal = maps:put(PartisanRef, Ref, State1),
+    {reply, PartisanRef, StateFinal};
+handle_call({demonitor, PartisanRef}, _From, State) ->
+    Ref = maps:get(PartisanRef, State),
+    erlang:demonitor(Ref),
+    State1 = maps:remove(PartisanRef, State),
+    StateFinal = maps:remove(Ref, State1),
+    {reply, true, StateFinal};
+handle_call(_Msg, _From, State) ->
+    {reply, ok, State}.
+
+%% @private
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info({'DOWN', Ref, process, Pid, Reason}, State) ->
+    {PartisanRef, PartisanRemote} = maps:get(Ref, State),
+    State1 = maps:remove(Ref, State),
+    StateFinal = maps:remove(PartisanRef, State1),
+    Resp = {'DOWN', PartisanRef, process, partisan_util:pid(Pid), Reason},
+    partisan_peer_service_manager:forward_message(PartisanRemote, Resp),
+    {noreply, StateFinal};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.
+
+%% @private
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/partisan_sup.erl
+++ b/src/partisan_sup.erl
@@ -48,7 +48,8 @@ init([]) ->
                  ?CHILD(Manager, worker),
                  ?CHILD(partisan_peer_service_events, worker),
                  ?CHILD(partisan_plumtree_backend, worker),
-                 ?CHILD(partisan_plumtree_broadcast, worker)
+                 ?CHILD(partisan_plumtree_broadcast, worker),
+                 ?CHILD(partisan_monitor, worker)
                  ]),
 
     %% Run a single backend for each label.


### PR DESCRIPTION
Given a `{partisan_remote_reference, Node, {partisan_process_reference,
PidAsList}}`, you will be able to call `partisan_monitor:monitor/1` in order to
monitor the process. This will message a named process on the `Node` to begin
monitoring the `PidAsList` as a proxy for the calling process, returning a
`partisan_encoded_reference`.

If the monitored process dies, it will send the down message to the local
`partisan_monitor` process which will do a lookup and forward the message off to
the remote monitoring process.

You can also call `partisan_monitor:demonitor/1`, handing it the
`partisan_encoded_reference`, in order to stop monitoring the remote process.

This is in reference to #45