### PR TITLE
fix ex_doc line break in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img alt="Partisan" width="600" src="https://github.com/lasp-lang/partisan/blob/e4ec25b547c4d50000250b904690b26594b3e72e/assets/partisan_logo_black.png?raw=true">
 
-
-![Version](https://img.shields.io/badge/version-5.0.0--rc.8-blue?style=for-the-badge)<br>
+![Version](https://img.shields.io/badge/version-5.0.0--rc.8-blue?style=for-the-badge)  
 ![Core Test Suite](https://img.shields.io/github/actions/workflow/status/lasp-lang/partisan/build_and_test.yml?&branch=master&label=core-test-suite&style=for-the-badge)
 ![OTP Test Suite](https://img.shields.io/github/actions/workflow/status/lasp-lang/partisan/otp-test.yml?&branch=master&label=otp-test-suite&style=for-the-badge)
 ![Alt Test Suite](https://img.shields.io/github/actions/workflow/status/lasp-lang/partisan/alt-test.yml?&branch=master&label=alt-test-suite&style=for-the-badge)


### PR DESCRIPTION
`<br>` doesn't seem to be supported by `ex_doc`:

![Screenshot 2024-03-08 18 15 55@2x](https://github.com/lasp-lang/partisan/assets/1732217/b67a2a0e-eb8f-4303-a1ae-3b1244492aba)

Using a end-of-line double space convention instead fixes this:

![Screenshot 2024-03-08 18 31 36@2x](https://github.com/lasp-lang/partisan/assets/1732217/23c801f9-8a23-48f1-9c44-c9a4ea17bb26)
