### PR TITLE
Fix formatting for partisan_config.erl documentation

### DIFF
--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -33,7 +33,7 @@ configuration options.
 Some options will only take effect after a restart of the Partisan application, while other will take effect while the application is still running.
 
 As per Erlang convention the options are given using the `sys.config` file under
-the `partisan' application section.
+the `partisan` application section.
 
 ## Example
 ```


### PR DESCRIPTION
The unclosed inline code block ` breaks the rendering:

<img width="931" height="512" alt="image" src="https://github.com/user-attachments/assets/6234f96d-8685-45f1-a282-feca242be497" />

