### PR TITLE
doc typo in partisan_config.erl

### DIFF
--- a/src/partisan_config.erl
+++ b/src/partisan_config.erl
@@ -33,7 +33,7 @@ configuration options.
 Some options will only take effect after a restart of the Partisan application, while other will take effect while the application is still running.
 
 As per Erlang convention the options are given using the `sys.config` file under
-the `partisan' application section.
+the `partisan` application section.
 
 ## Example
 ```


### PR DESCRIPTION
The doc contains a typo (notice the wrong tick is used):
```markdown
[...] the `partisan' application [...]
```
instead of:
```markdown
[...] the `partisan` application [...]
```

This breaks the documentation